### PR TITLE
Support aggregating the authors label & the buildpack maintainers label into the docker slim xray maintainers field

### DIFF
--- a/pkg/app/master/commands/xray/handler.go
+++ b/pkg/app/master/commands/xray/handler.go
@@ -271,7 +271,7 @@ func OnCommand(
 	}
 
 	for k, v := range cmdReport.SourceImage.Labels {
-		if strings.ToLower(k) == "maintainer" || k == "org.opencontainers.image.authors" {
+		if strings.ToLower(k) == "maintainer" || strings.ToLower(k) == "author" || strings.ToLower(k) == "authors" || k == "org.opencontainers.image.authors" {
 			maintainers[v] = struct{}{}
 		}
 	}


### PR DESCRIPTION
[Fixes-229](https://github.com/docker-slim/docker-slim/issues/229)
==================================================================

What
===============
Aggregate the authors label & buildpack maintainers label into the maintainers field created via a docker slim xray.

Why
===============
Enhance docker slim `maintainers` data point.

How Tested
===============

  1. Run `docker pull rocker/rstudio:latest`
  2. Run `docker pull buildpacksio/pack:latest`
  3. Run `docker-slim xray $RSTUDIO_IMAGE_ID`
  4. Inspect  `slim.report.json`
  5. You should see a populated `maintainers` field
  6. Run `docker-slim xray $BUILDPACKIO_PACK_IMAGE_ID`
  7. Inspect  `slim.report.json`
  8. You should see a populated `maintainers` field



