### PR TITLE
feat: server sub command for registry

### DIFF
--- a/pkg/app/master/commands/registry/cli.go
+++ b/pkg/app/master/commands/registry/cli.go
@@ -14,12 +14,14 @@ const (
 	Usage = "Execute registry operations"
 	Alias = "r"
 
-	PullCmdName      = "pull"
-	PullCmdNameUsage = "Pull a container image from registry"
-	PushCmdName      = "push"
-	PushCmdNameUsage = "Push a container image to a registry"
-	CopyCmdName      = "copy"
-	CopyCmdNameUsage = "Copy a container image from one registry to another"
+	PullCmdName        = "pull"
+	PullCmdNameUsage   = "Pull a container image from registry"
+	PushCmdName        = "push"
+	PushCmdNameUsage   = "Push a container image to a registry"
+	CopyCmdName        = "copy"
+	CopyCmdNameUsage   = "Copy a container image from one registry to another"
+	ServerCmdName      = "server"
+	ServerCmdNameUsage = "Start a registry server"
 )
 
 func fullCmdName(subCmdName string) string {
@@ -104,6 +106,20 @@ var CLI = &cli.Command{
 
 				xc := app.NewExecutionContext(fullCmdName(CopyCmdName), ctx.String(commands.FlagConsoleFormat))
 				OnCopyCommand(xc, gcvalues)
+				return nil
+			},
+		},
+		{
+			Name:  ServerCmdName,
+			Usage: ServerCmdNameUsage,
+			Action: func(ctx *cli.Context) error {
+				gcvalues, err := commands.GlobalFlagValues(ctx)
+				if err != nil {
+					return err
+				}
+
+				xc := app.NewExecutionContext(fullCmdName(ServerCmdName), ctx.String(commands.FlagConsoleFormat))
+				OnServerCommand(xc, gcvalues)
 				return nil
 			},
 		},


### PR DESCRIPTION
This commit adds the server sub command for registry command

Signed-off-by: Shikhar Vashistha <51105234+shikharvashistha@users.noreply.github.com>

[Fixes-375](https://github.com/docker-slim/docker-slim/issues/375)
==================================================================
This pull requests introduces server sub command for registry command as per the issue #375 

What
===============
This commit includes the code for introducing `server` as a CLI command and it's handler.

Why
===============
As requested mentioned in #375 this will serve as a solution to it.

How Tested
===============
Compiled the code, kindly guide me if any other type of testing is required.

------------------------

Greetings of the day @kcq,

Kindly review the pull and let me know in case of any changes if required.

Thanks in advance
@shikharvashistha