### PR TITLE
Update install-slim.sh

### DIFF
--- a/scripts/install-slim.sh
+++ b/scripts/install-slim.sh
@@ -73,10 +73,10 @@ function get_slim() {
   # /usr/local/bin should be present on Linux and macOS hosts. Just be sure.
   if [ -d /usr/local/bin ]; then
     echo " - Placing slim in /usr/local/bin"
-    mv "${TMP_DIR}/dist_${DIST}/slim" /usr/local/bin/
-    mv "${TMP_DIR}/dist_${DIST}/slim-sensor" /usr/local/bin/
-    chmod +x /usr/local/bin/slim
-    chmod +x /usr/local/bin/slim-sensor
+    mv "${TMP_DIR}/dist_${DIST}/docker-slim" /usr/local/bin/
+    mv "${TMP_DIR}/dist_${DIST}/docker-slim-sensor" /usr/local/bin/
+    chmod +x /usr/local/bin/docker-slim
+    chmod +x /usr/local/bin/docker-slim-sensor
 
     echo " - Cleaning up"
     rm -rf "${TMP_DIR}"

--- a/scripts/install-slim.sh
+++ b/scripts/install-slim.sh
@@ -11,8 +11,7 @@ function get_slim() {
   local VER=""
 
   # Get the current released tag_name
-  VER=$(curl -sL https://api.github.com/repos/docker-slim/docker-slim/releases \
-        | grep tag_name | head -n1 | cut -d'"' -f4)
+  VER="1.39.0"
 
   if [ -n "${VER}" ]; then
     URL="https://downloads.dockerslim.com/releases/${VER}"


### PR DESCRIPTION
[Fixes-448](https://github.com/docker-slim/docker-slim/issues/448)
==================================================================

What
===============
Modification to the files names referenced in the script. The "docker-" part of the files in the tar were not referenced in the script.

Why
===============
It seems that there is an error in the scripted install script.

How Tested
===============
Modified script was tested in an Azure Devops pipeline and now it is working again.

