### PR TITLE
docs: Specify arg format in HTTPProbeCmd's help

### DIFF
--- a/pkg/app/master/commands/cliflags.go
+++ b/pkg/app/master/commands/cliflags.go
@@ -209,7 +209,7 @@ const (
 
 	FlagHTTPProbeUsage                 = "Enable or disable HTTP probing"
 	FlagHTTPProbeOffUsage              = "Alternative way to disable HTTP probing"
-	FlagHTTPProbeCmdUsage              = "User defined HTTP probes"
+	FlagHTTPProbeCmdUsage              = "User defined HTTP probe(s) as [[[[\"crawl\":]PROTO:]METHOD:]PATH]"
 	FlagHTTPProbeCmdFileUsage          = "File with user defined HTTP probes"
 	FlagHTTPProbeStartWaitUsage        = "Number of seconds to wait before starting HTTP probing"
 	FlagHTTPProbeRetryCountUsage       = "Number of retries for each HTTP probe"


### PR DESCRIPTION
What
===============
Annotates `--http-probe-cmd` with some guidance on how to format its argument.

Why
===============
Based on "cmd" in the option's name, my misadventures began when I tried `--http-probe-cmd 'curl http://127.0.0.1:1234/test'`.  That gives the following error:
```
cmd=build error=param.http.probe message='invalid HTTP probe command protocol: curl http://127.0.0.1:1234/test'
```

Seizing on "protocol", I then tried a number of other variations, like dropping the `curl` and just using `http://127.0.0.1:1234/test` (yields `invalid HTTP probe command method`), and then adding `GET` as the first parameter (puts me back at square 1 with an "protocol" error).  Turns out the correct format is any of the following:

1. `''` (i.e., blank) &mdash; runs a GET on `/` via HTTP.
2. `<path>` &mdash; runs a GET on `<path>` via HTTP.
3. `<method>:<path>` &mdash; runs a `<method>` on `<path>` via HTTP
4. `<protocol>:<method>:<path>` &mdash; as above, but with `<protocol>`
5. Four more varations, because each of these can also have `crawl:` prepended.  If present (or if `crawl` is passed as a bareword), Crawl mode is activated.

This is probably documented somewhere already.  But now it's readily accessible in the first place people will look: the `--help` of the command itself.

How Tested
===============
n/a