### PR TITLE
Change the call to slim --version in install-slim.sh

### DIFF
--- a/scripts/install-slim.sh
+++ b/scripts/install-slim.sh
@@ -81,7 +81,7 @@ function get_slim() {
     echo " - Cleaning up"
     rm -rf "${TMP_DIR}"
     echo -en " - "
-    docker-slim --version
+    slim --version
   else
     echo "ERROR! /usr/local/bin is not present. Install aborted."
     rm -rf "${TMP_DIR}"


### PR DESCRIPTION
Signed-off-by: Yuriy Kovalchuk <yk@koduro.com>

[Fixes-#461](https://github.com/docker-slim/docker-slim/issues/461)
==================================================================

What
===============
Changed the call from 'docker-slim' to 'slim'

Why
===============
The renaming effort must have missed this call.

How Tested
===============
Tested by running the script on Ubuntu 22.04.1 LTS

$ curl -sL https://raw.githubusercontent.com/notemptylist/slim/master/scripts/install-slim.sh | sudo -E bash -
Slim scripted install
 - Downloading https://downloads.dockerslim.com/releases/1.40.0/dist_linux.tar.gz
 - Unpacking dist_linux.tar.gz
 - Placing slim in /usr/local/bin
 - Cleaning up
 - slim version linux|Transformer|1.40.0|a4bb798922820523fceedb9121f5bcfdfc9f2901|2023-01-15_09:42:23PM
