### PR TITLE
Pin Actions workflow versions for deterministic execution. Configure Dependabot to keep workflows up to date.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:

--- a/.github/workflows/acceptance-testing-bats.yml
+++ b/.github/workflows/acceptance-testing-bats.yml
@@ -14,7 +14,7 @@ jobs:
         go: ['1.16', '1.18']
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/cache@v3
+      - uses: actions/cache@v3.2.4
         with:
           path: |
             ~/.cache/go-build
@@ -23,12 +23,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
           submodules: recursive
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/acceptance-testing-e2e.yml
+++ b/.github/workflows/acceptance-testing-e2e.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out slimtoolkit/slim repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Set up Go development environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.16.0'
 
@@ -23,28 +23,28 @@ jobs:
         run: make build
 
       - name: Upload Slim app binaries (Linux, amd64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: dist_linux
           path: dist_linux
           retention-days: 1
 
       - name: Upload Slim app binaries (Linux, arm64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: dist_linux_arm64
           path: dist_linux_arm64
           retention-days: 1
 
       - name: Upload Slim app binaries (Linux, arm)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: dist_linux_arm
           path: dist_linux_arm
           retention-days: 1
 
       - name: Upload Slim app binaries (macOS, amd64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: dist_mac
           path: dist_mac
@@ -64,15 +64,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out slimtoolkit/slim repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Set up Go development environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.16.0'
 
       - name: Download Slim app binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           name: ${{ matrix.bin_artifacts }}
           path: bin
@@ -116,16 +116,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out slimtoolkit/slim repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Check out slimtoolkit/examples repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
         with:
           repository: slimtoolkit/examples
           path: e2e
 
       - name: Download Slim app binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           name: ${{ matrix.bin_artifacts }}
           path: bin

--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: checkout
         id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.6.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -22,10 +22,10 @@ jobs:
       # codesee-detect-languages has an output with id languages.
       - name: Detect Languages
         id: detect-languages
-        uses: Codesee-io/codesee-detect-languages-action@latest
+        uses: Codesee-io/codesee-detect-languages-action@v1
 
       - name: Configure JDK 16
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v2.5.0
         if: ${{ fromJSON(steps.detect-languages.outputs.languages).java }}
         with:
           java-version: '16'
@@ -34,20 +34,20 @@ jobs:
       # CodeSee Maps Go support uses a static binary so there's no setup step required.
 
       - name: Configure Node.js 14
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v2.5.1
         if: ${{ fromJSON(steps.detect-languages.outputs.languages).javascript }}
         with:
           node-version: '14'
 
       - name: Configure Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v2.3.2
         if: ${{ fromJSON(steps.detect-languages.outputs.languages).python }}
         with:
           python-version: '3.x'
           architecture: 'x64'
 
       - name: Configure Ruby '3.x'
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.134.0
         if: ${{ fromJSON(steps.detect-languages.outputs.languages).ruby }}
         with:
           ruby-version: '3.0'
@@ -56,7 +56,7 @@ jobs:
 
       - name: Generate Map
         id: generate-map
-        uses: Codesee-io/codesee-map-action@latest
+        uses: Codesee-io/codesee-map-action@v1
         with:
           step: map
           github_ref: ${{ github.ref }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload Map
         id: upload-map
-        uses: Codesee-io/codesee-map-action@latest
+        uses: Codesee-io/codesee-map-action@v1
         with:
           step: mapUpload
           api_token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
       
       - name: Insights
         id: insights
-        uses: Codesee-io/codesee-map-action@latest
+        uses: Codesee-io/codesee-map-action@v1
         with:
           step: insights
           api_token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out slimtoolkit/slim repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Set up Go development environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.16.0'
 


### PR DESCRIPTION
Signed-off-by: Chris Thach <12981621+cthach@users.noreply.github.com>

What
===============

1. Pins all GitHub Actions reusable workflow versions to the latest compatible semantic version.
1. Configures Dependabot to submit PRs when a reusable workflow is updated.

Why
===============

By pinning to a specific workflow version, we prevent workflow breakage or unexpected behavior when workflow owners publish updates.

Dependabot can be configured to handle the chore of updating workflow versions when new ones are published.

How Tested
===============

Searching for when a reusable workflow is used and manually verifying the tag in the upstream repository.

```shell
$ grep --fixed-strings 'uses:' --no-filename --recursive .github/workflows | awk '{ print $NF }' | sort --unique

actions/cache@v3.2.4
actions/checkout@v2.6.0
actions/checkout@v3.3.0
actions/download-artifact@v3.0.2
actions/setup-go@v3.5.0
actions/setup-java@v2.5.0
actions/setup-node@v2.5.1
actions/setup-python@v2.3.2
actions/upload-artifact@v3.1.2
Codesee-io/codesee-detect-languages-action@v1
Codesee-io/codesee-map-action@v1
ruby/setup-ruby@v1.134.0
```

