### PR TITLE
refactor(reverse): dockerfilefromhistory default processor

### DIFF
--- a/pkg/docker/dockerfile/reverse/reverse.go
+++ b/pkg/docker/dockerfile/reverse/reverse.go
@@ -188,6 +188,80 @@ type tbrecord struct {
 
 const tbDuration = (15 * time.Minute)
 
+func processRawInst(rawInst string) (string, bool) {
+	var inst string
+	isExecForm := false
+
+	//TODO: need to refactor
+	processed := false
+	//rawInst := rawLine
+	if strings.HasPrefix(rawInst, runInstArgsPrefix) {
+		parts := strings.SplitN(rawInst, " ", 2)
+		if len(parts) == 2 {
+			withArgs := strings.TrimSpace(parts[1])
+			argNumStr := parts[0][1:]
+			argNum, err := strconv.Atoi(argNumStr)
+			if err == nil {
+				if withArgsArray, err := shlex.Split(withArgs); err == nil {
+					if len(withArgsArray) > argNum {
+						rawInstParts := withArgsArray[argNum:]
+						processed = true
+						if len(rawInstParts) > 2 &&
+							rawInstParts[0] == defaultRunInstShell &&
+							rawInstParts[1] == "-c" {
+							isExecForm = false
+							rawInstParts = rawInstParts[2:]
+
+							inst = fmt.Sprintf("RUN %s", strings.Join(rawInstParts, " "))
+							inst = strings.TrimSpace(inst)
+						} else {
+							isExecForm = true
+
+							var outJson bytes.Buffer
+							encoder := json.NewEncoder(&outJson)
+							encoder.SetEscapeHTML(false)
+							err := encoder.Encode(rawInstParts)
+							if err == nil {
+								inst = fmt.Sprintf("RUN %s", outJson.String())
+							}
+						}
+					} else {
+						log.Infof("ReverseDockerfileFromHistory - RUN with ARGs - malformed - %v (%v)", rawInst, err)
+					}
+				} else {
+					log.Infof("ReverseDockerfileFromHistory - RUN with ARGs - malformed - %v (%v)", rawInst, err)
+				}
+
+			} else {
+				log.Infof("ReverseDockerfileFromHistory - RUN with ARGs - malformed number of ARGs - %v (%v)", rawInst, err)
+			}
+		} else {
+			log.Infof("ReverseDockerfileFromHistory - RUN with ARGs - unexpected number of parts - %v", rawInst)
+		}
+	}
+	//todo: RUN inst with ARGS for buildkit
+	if hasInstructionPrefix(rawInst) {
+		inst = rawInst
+	} else {
+		if !processed {
+			//default to RUN instruction in exec form
+			isExecForm = true
+			inst = instPrefixRun + rawInst
+			if outArray, err := shlex.Split(rawInst); err == nil {
+				var outJson bytes.Buffer
+				encoder := json.NewEncoder(&outJson)
+				encoder.SetEscapeHTML(false)
+				err := encoder.Encode(outArray)
+				if err == nil {
+					inst = fmt.Sprintf("RUN %s", outJson.String())
+				}
+			}
+		}
+	}
+
+	return inst, isExecForm
+}
+
 // DockerfileFromHistory recreates Dockerfile information from container image history
 func DockerfileFromHistory(apiClient *docker.Client, imageID string) (*Dockerfile, error) {
 	//TODO: make it possible to pass the history information as a param
@@ -264,72 +338,7 @@ func DockerfileFromHistory(apiClient *docker.Client, imageID string) (*Dockerfil
 					inst = instPrefixRun + runData
 				}
 			default:
-				//TODO: need to refactor
-				processed := false
-				//rawInst := rawLine
-				if strings.HasPrefix(rawInst, runInstArgsPrefix) {
-					parts := strings.SplitN(rawInst, " ", 2)
-					if len(parts) == 2 {
-						withArgs := strings.TrimSpace(parts[1])
-						argNumStr := parts[0][1:]
-						argNum, err := strconv.Atoi(argNumStr)
-						if err == nil {
-							if withArgsArray, err := shlex.Split(withArgs); err == nil {
-								if len(withArgsArray) > argNum {
-									rawInstParts := withArgsArray[argNum:]
-									processed = true
-									if len(rawInstParts) > 2 &&
-										rawInstParts[0] == defaultRunInstShell &&
-										rawInstParts[1] == "-c" {
-										isExecForm = false
-										rawInstParts = rawInstParts[2:]
-
-										inst = fmt.Sprintf("RUN %s", strings.Join(rawInstParts, " "))
-										inst = strings.TrimSpace(inst)
-									} else {
-										isExecForm = true
-
-										var outJson bytes.Buffer
-										encoder := json.NewEncoder(&outJson)
-										encoder.SetEscapeHTML(false)
-										err := encoder.Encode(rawInstParts)
-										if err == nil {
-											inst = fmt.Sprintf("RUN %s", outJson.String())
-										}
-									}
-								} else {
-									log.Infof("ReverseDockerfileFromHistory - RUN with ARGs - malformed - %v (%v)", rawInst, err)
-								}
-							} else {
-								log.Infof("ReverseDockerfileFromHistory - RUN with ARGs - malformed - %v (%v)", rawInst, err)
-							}
-
-						} else {
-							log.Infof("ReverseDockerfileFromHistory - RUN with ARGs - malformed number of ARGs - %v (%v)", rawInst, err)
-						}
-					} else {
-						log.Infof("ReverseDockerfileFromHistory - RUN with ARGs - unexpected number of parts - %v", rawInst)
-					}
-				}
-				//todo: RUN inst with ARGS for buildkit
-				if hasInstructionPrefix(rawInst) {
-					inst = rawInst
-				} else {
-					if !processed {
-						//default to RUN instruction in exec form
-						isExecForm = true
-						inst = instPrefixRun + rawInst
-						if outArray, err := shlex.Split(rawInst); err == nil {
-							var outJson bytes.Buffer
-							encoder := json.NewEncoder(&outJson)
-							encoder.SetEscapeHTML(false)
-							err := encoder.Encode(outArray)
-							if err == nil {
-								inst = fmt.Sprintf("RUN %s", outJson.String())
-							}
-						}
-					}
-				}
+				inst, isExecForm := processRawInst(rawInst)
 			}
 
 			//NOTE: Dockerfile instructions can be any case, but the instructions from history are always uppercase

--- a/pkg/docker/dockerfile/reverse/reverse_test.go
+++ b/pkg/docker/dockerfile/reverse/reverse_test.go
@@ -2,10 +2,13 @@ package reverse
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	dockerclient "github.com/fsouza/go-dockerclient"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -107,4 +110,215 @@ func TestHealthCheck(t *testing.T) {
 		assert.Equal(t, &testData.expectedHealthConf, healthConf)
 		assert.Equal(t, testData.reconstructedHealthcheck, res)
 	}
+}
+
+func TestProcessRawInst(t *testing.T) {
+	t.Run("when the instruction is in args format", func(t *testing.T) {
+		t.Run("but does not have arguments", func(t *testing.T) {
+			raw := "|/bin/sh"
+
+			t.Run("it treats the instruction as a pure RUN", func(t *testing.T) {
+				expected := "RUN [\"|/bin/sh\"]\n"
+				result, _ := processRawInst(raw)
+
+				assert.Equal(t, expected, result)
+			})
+
+			t.Run("it returns true as the exec form", func(t *testing.T) {
+				_, ief := processRawInst(raw)
+
+				assert.True(t, ief)
+			})
+
+			t.Run("it logs the bad part count", func(t *testing.T) {
+				logged := withFakeLogger(func() {
+					processRawInst(raw)
+				})
+
+				assert.True(t, logged.Match("unexpected number of parts"))
+			})
+		})
+
+		t.Run("but contains bad shell syntax", func(t *testing.T) {
+			raw := "|1 /bin/sh -c echo '"
+
+			t.Run("it treats the instruction as a pure RUN", func(t *testing.T) {
+				expected := "RUN |1 /bin/sh -c echo '"
+				result, _ := processRawInst(raw)
+
+				assert.Equal(t, expected, result)
+			})
+
+			t.Run("it returns true as the exec form", func(t *testing.T) {
+				_, ief := processRawInst(raw)
+
+				assert.True(t, ief)
+			})
+
+			t.Run("it logs the bad command", func(t *testing.T) {
+				logged := withFakeLogger(func() {
+					processRawInst(raw)
+				})
+
+				assert.True(t, logged.Match("malformed - "))
+			})
+		})
+
+		t.Run("but contains too few args", func(t *testing.T) {
+			raw := "|4 /bin/sh -c echo foo"
+
+			t.Run("it treats the instruction as a pure RUN", func(t *testing.T) {
+				expected := "RUN [\"|4\",\"/bin/sh\",\"-c\",\"echo\",\"foo\"]\n"
+				result, _ := processRawInst(raw)
+
+				assert.Equal(t, expected, result)
+			})
+
+			t.Run("it returns true as the exec form", func(t *testing.T) {
+				_, ief := processRawInst(raw)
+
+				assert.True(t, ief)
+			})
+
+			t.Run("it logs the bad command", func(t *testing.T) {
+				logged := withFakeLogger(func() {
+					processRawInst(raw)
+				})
+
+				assert.True(t, logged.Match("malformed - "))
+			})
+		})
+
+		t.Run("but does not have an argnumment number", func(t *testing.T) {
+			raw := "|/bin/sh -c echo 'blah'"
+
+			t.Run("it treats the instruction as a pure RUN", func(t *testing.T) {
+				expected := "RUN [\"|/bin/sh\",\"-c\",\"echo\",\"blah\"]\n"
+				result, _ := processRawInst(raw)
+
+				assert.Equal(t, expected, result)
+			})
+
+			t.Run("it returns true as the exec form", func(t *testing.T) {
+				_, ief := processRawInst(raw)
+
+				assert.True(t, ief)
+			})
+
+			t.Run("it logs the bad arg count", func(t *testing.T) {
+				logged := withFakeLogger(func() {
+					processRawInst(raw)
+				})
+
+				assert.True(t, logged.Match("malformed number of ARGs"))
+			})
+		})
+
+		t.Run("and is a well-formed shell format instruction", func(t *testing.T) {
+			raw := "|0 /bin/sh -c echo 'blah'"
+
+			t.Run("it processes the instruction as a shell command", func(t *testing.T) {
+				expected := "RUN echo blah"
+				result, _ := processRawInst(raw)
+
+				assert.Equal(t, expected, result)
+			})
+
+			t.Run("it returns false as the exec form", func(t *testing.T) {
+				_, ief := processRawInst(raw)
+
+				assert.False(t, ief)
+			})
+		})
+
+		t.Run("and is a well-formed raw instruction", func(t *testing.T) {
+			raw := "|0 echo 'blah'"
+
+			t.Run("it processes the instruction as an exec command", func(t *testing.T) {
+				expected := "RUN [\"echo\",\"blah\"]\n"
+				result, _ := processRawInst(raw)
+
+				assert.Equal(t, expected, result)
+			})
+
+			t.Run("it returns true as the exec form", func(t *testing.T) {
+				_, ief := processRawInst(raw)
+
+				assert.True(t, ief)
+			})
+		})
+	})
+
+	t.Run("when the instruction has an uncaught instruction prefix", func(t *testing.T) {
+		raw := "EXPOSE 8675"
+
+		t.Run("it passes the instruction back unchanged", func(t *testing.T) {
+			result, _ := processRawInst(raw)
+
+			assert.Equal(t, raw, result)
+		})
+
+		t.Run("it returns false as the exec form", func(t *testing.T) {
+			_, ief := processRawInst(raw)
+
+			assert.False(t, ief)
+		})
+	})
+
+	t.Run("when the instruction is raw text", func(t *testing.T) {
+		raw := "foo bar"
+
+		t.Run("it is treated as an exec format RUN", func(t *testing.T) {
+			expected := "RUN [\"foo\",\"bar\"]\n"
+			result, _ := processRawInst(raw)
+
+			assert.Equal(t, expected, result)
+		})
+
+		t.Run("it returns true as the exec form", func(t *testing.T) {
+			_, ief := processRawInst(raw)
+
+			assert.True(t, ief)
+		})
+	})
+
+	t.Run("when the instruction is in shell format", func(t *testing.T) {})
+
+	t.Run("when the instruction is in  no-op format", func(t *testing.T) {})
+
+	t.Run("when the instruction is in shell command format", func(t *testing.T) {})
+}
+
+type fakeLogger struct {
+	Lines []string
+}
+
+func (l *fakeLogger) Write(msg []byte) (int, error) {
+	if l.Lines == nil {
+		l.Lines = []string{}
+	}
+
+	l.Lines = append(l.Lines, string(msg))
+
+	return len(msg), nil
+}
+
+func (l *fakeLogger) Match(substr string) bool {
+	for _, line := range l.Lines {
+		if strings.Contains(line, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func withFakeLogger(proc func()) *fakeLogger {
+	logger := &fakeLogger{}
+	log.SetOutput(logger)
+
+	proc()
+
+	log.SetOutput(os.Stderr)
+	return logger
 }


### PR DESCRIPTION
Per the desire expressed in the `TODO` in the default raw instruction processing case in `DockerfileFromHistory`, this adds tests for that processor and refactors it.

The end result *increases* cumulative cyclomatic complexity a few points, but generally drops the complexity of the individual pieces through conditional flattening and code deduplication, provides a clear path towards extension, and generally makes the default processor a good deal easier to reason about.