### PR TITLE
sysenv_linux.go: fix SeccompMode always using /proc/self/ instead of $pid

### DIFF
--- a/pkg/sysenv/sysenv_linux.go
+++ b/pkg/sysenv/sysenv_linux.go
@@ -180,7 +180,7 @@ var seccompModes = map[string]SeccompModeName{
 const procStatusPat = "/proc/%s/status"
 
 func SeccompMode(pid int) (SeccompModeName, error) {
-	fname := procFileName(0, "status")
+	fname := procFileName(pid, "status")
 	fdata, err := fileData(fname)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This commit fixes a bug in SeccompMode where the `pid` argument was unused while it should have been passed further to the function that creates the `/proc/$pid/status` path (and when `pid=0` was provided, it returned `/proc/self/status`).

I have not tested this change, so please do. I have only spotted this bug by randomly looking at the relevant code.

As far as I checked, the bug fixed here -- where `SeccompMode` always returned seccomp status for the self and not the target process -- does not seem to be exploitable/triggerable anywhere else in the code. The `SeccompMode` seems to only be used in the same file as `SeccompMode(pid=0)`. However, fixing this bug will prevent future bugs if `SeccompMode` were used with another pid argument.