### PR TITLE
fixed: unknown --directory flag causing script to fail

### DIFF
--- a/scripts/install-slim.sh
+++ b/scripts/install-slim.sh
@@ -57,7 +57,7 @@ function get_slim() {
   FILENAME="dist_${DIST}.${EXT}"
 
   echo " - Downloading ${URL}/${FILENAME}"
-  TMP_DIR=$(mktemp --directory)
+  TMP_DIR=$(mktemp -d)
   curl -sLo "${TMP_DIR}/${FILENAME}" "${URL}/${FILENAME}"
 
   echo " - Unpacking ${FILENAME}"


### PR DESCRIPTION
[Fixes-###](https://github.com/docker-slim/docker-slim/issues/###)
==================================================================

What
===============

installation script not working , after diagnosis the 'mktemp' command doesnt take `--directory` flag but instead a `-d` flag


Why
===============


How Tested
===============

```bash
sudo ./scripts/install-slim.sh
```
