### PR TITLE
Fix big in fsutil error format string

### DIFF
--- a/pkg/util/fsutil/fsutil.go
+++ b/pkg/util/fsutil/fsutil.go
@@ -465,7 +465,7 @@ func cloneDirPath(src, dst string) {
 		//need to research when we might miss intermediate directories
 		err = os.MkdirAll(dir.dst, 0777)
 		if err != nil {
-			log.Errorf("cloneDirPath() - os.MkdirAll(%v) error - %v", dir.dst)
+			log.Errorf("cloneDirPath() - os.MkdirAll(%v) error - %v", dir.dst, dir.dst)
 		}
 		//if err != nil && !os.IsExist(err) {
 		//	errutil.FailOn(err)


### PR DESCRIPTION
[Fixes-###](https://github.com/docker-slim/docker-slim/issues/###)
==================================================================

What
===============
Changes the error string for an error check in fsutil.

Why
===============
Unit tests were failing for me due to what looks like an error.

How Tested
===============
By running the unit tests, which now exits with a successful status code.

