### PR TITLE
chore: use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...))

### DIFF
--- a/pkg/app/master/inspectors/image/image_inspector.go
+++ b/pkg/app/master/inspectors/image/image_inspector.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -149,7 +148,7 @@ func getRegistryCredential(registryAccount, registrySecret, dockerConfigPath, re
 		return
 	}
 
-	missingAuthConfigErr := errors.New(fmt.Sprintf("could not find an auth config for registry - %s", registry))
+	missingAuthConfigErr := fmt.Errorf("could not find an auth config for registry - %s", registry)
 	if dockerConfigPath != "" {
 		dAuthConfigs, err := docker.NewAuthConfigurationsFromFile(dockerConfigPath)
 		if err != nil {

--- a/pkg/docker/dockerfile/reverse/reverse.go
+++ b/pkg/docker/dockerfile/reverse/reverse.go
@@ -827,7 +827,7 @@ func deserialiseHealtheckInstruction(data string) (string, *docker.HealthConfig,
 		} else if strings.Index(paramParts[3], `\`) == 0 {
 			// retries is printed as a C-escape
 			if len(paramParts[3]) != 2 {
-				err = errors.New(fmt.Sprintf("expected retries (%s) to be an escape sequence", paramParts[3]))
+				err = fmt.Errorf("expected retries (%s) to be an escape sequence", paramParts[3])
 			} else {
 				escapeCodes := map[byte]int64{
 					byte('a'): 7,
@@ -840,7 +840,7 @@ func deserialiseHealtheckInstruction(data string) (string, *docker.HealthConfig,
 				}
 				var ok bool
 				if retries, ok = escapeCodes[(paramParts[3])[1]]; !ok {
-					err = errors.New(fmt.Sprintf("got an invalid escape sequence: %s", paramParts[3]))
+					err = fmt.Errorf("got an invalid escape sequence: %s", paramParts[3])
 				}
 			}
 		} else {


### PR DESCRIPTION
[Fixes-###](https://github.com/docker-slim/docker-slim/issues/###)
==================================================================

What
===============
use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...))

Why
===============
should use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...))

How Tested
===============
staticcheck

