### PR TITLE
tests: Remove redundant Go caching step

### DIFF
--- a/.github/workflows/acceptance-testing-bats.yml
+++ b/.github/workflows/acceptance-testing-bats.yml
@@ -14,15 +14,6 @@ jobs:
         go: ['1.19']
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/cache@v3.3.1
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - uses: actions/checkout@v3.5.3
         with:
           fetch-depth: 0


### PR DESCRIPTION
[Fixes-###](https://github.com/docker-slim/docker-slim/issues/###)
==================================================================
/

What
===============
Remove the caching step, redundant since actions/setup-go v4, see:
* https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs
* https://github.com/actions/setup-go/releases/tag/v4.0.0
* https://github.com/slimtoolkit/slim/pull/494

Why
===============
To 
* save some running time,
* reduce unneeded code
* remove a dependancy

How Tested
===============
/

