### PR TITLE
fix: make help command to show target name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ fmt:  ## format all golang files
 	'$(CURDIR)/scripts/src.fmt.sh'
 
 help: ## prints out the menu of command options
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@awk -F ':.*?## ' '/^[a-zA-Z0-9_-]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 inspect: ## report suspicious constructs and linting errors
 	'$(CURDIR)/scripts/src.inspect.sh'


### PR DESCRIPTION
[Fixes-###](https://github.com/docker-slim/docker-slim/issues/###)
==================================================================
https://github.com/slimtoolkit/slim/issues/570

What
===============
Fix make help command to show target name in first column

Why
===============
The current behaviour does not show the actual make target name to the user

How Tested
===============
ran make help command with the fix
![Screen Shot 2023-08-31 at 5 27 20 PM](https://github.com/slimtoolkit/slim/assets/14129300/49aad64f-07b5-48b7-a4a9-081d36947556)


