### PR TITLE
fix : build m1 script  by adding `--always` option to `git describe --tag`

### DIFF
--- a/scripts/src.build.m1.sh
+++ b/scripts/src.build.m1.sh
@@ -14,7 +14,7 @@ BUILD_TIME="$(date -u '+%Y-%m-%d_%I:%M:%S%p')"
 TAG="current"
 REVISION="current"
 if hash git 2>/dev/null && [ -e $BDIR/.git ]; then
-  TAG="$(git describe --tags)"
+  TAG="$(git describe --tags --always)"
   REVISION="$(git rev-parse HEAD)"
 fi
 


### PR DESCRIPTION
[Fixes-575](https://github.com/slimtoolkit/slim/issues/575)
==================================================================

What
===============
fix build script for mac m1

Why
===============
current behaviour
```
reeta@Reetas-MacBook-Pro slim % make build_m1
'/Users/reeta/git/slim/scripts/src.build.m1.sh'
~/git/slim ~/git/slim
fatal: No names found, cannot describe anything.
make: *** [build_m1] Error 128
reeta@Reetas-MacBook-Pro slim % 
```

How Tested
===============
works fine after the fix
```
reeta@Reetas-MacBook-Pro slim % make build_m1
'/Users/reeta/git/slim/scripts/src.build.m1.sh'
~/git/slim ~/git/slim
found go binary: /usr/local/go/bin/go
saving go binary hash: sha256:7bc8c84f47c54b8a5a842b0b4d6287b4f54d5cb3e489e7871ed88dbe7e06cfdf
~/git/slim/cmd/slim ~/git/slim ~/git/slim
~/git/slim ~/git/slim
~/git/slim/cmd/slim-sensor ~/git/slim ~/git/slim
~/git/slim ~/git/slim
/Users/reeta/git/slim/dist_mac_m1/.slim-state/images/f6648c04cd6ce95adc05b3aa55265007b95d64d508755be8506cee652792952c/artifacts/Dockerfile.fat
/Users/reeta/git/slim/dist_mac_m1/.slim-state/images/f6648c04cd6ce95adc05b3aa55265007b95d64d508755be8506cee652792952c/artifacts
/Users/reeta/git/slim/dist_mac_m1/.slim-state/images/f6648c04cd6ce95adc05b3aa55265007b95d64d508755be8506cee652792952c
/Users/reeta/git/slim/dist_mac_m1/.slim-state/images
/Users/reeta/git/slim/dist_mac_m1/.slim-state
/Users/reeta/git/slim/dist_mac_m1/slim-sensor
/Users/reeta/git/slim/dist_mac_m1/slim
/Users/reeta/git/slim/dist_mac_m1/docker-slim
/Users/reeta/git/slim/dist_mac_m1
~/git/slim/dist_mac_m1 ~/git/slim ~/git/slim
~/git/slim ~/git/slim
~/git/slim ~/git/slim ~/git/slim
updating: dist_mac_m1/ (stored 0%)
updating: dist_mac_m1/slim-sensor (deflated 61%)
updating: dist_mac_m1/slim (deflated 71%)
updating: dist_mac_m1/docker-slim (deflated 71%)
/Users/reeta/git/slim/bin/mac_m1/slim
/Users/reeta/git/slim/bin/mac_m1
/Users/reeta/git/slim/bin/linux_arm64/slim-sensor
/Users/reeta/git/slim/bin/linux_arm64
/Users/reeta/git/slim/bin
reeta@Reetas-MacBook-Pro slim % 
```

