### PR TITLE
add support for --env-file to build and profile commands

### DIFF
--- a/pkg/app/master/commands/build/cli.go
+++ b/pkg/app/master/commands/build/cli.go
@@ -81,6 +81,7 @@ var CLI = &cli.Command{
 		commands.Cflag(commands.FlagCmd),
 		commands.Cflag(commands.FlagWorkdir),
 		commands.Cflag(commands.FlagEnv),
+		commands.Cflag(commands.FlagEnvFile),
 		commands.Cflag(commands.FlagLabel),
 		commands.Cflag(commands.FlagVolume),
 		commands.Cflag(commands.FlagLink),

--- a/pkg/app/master/commands/build/prompt.go
+++ b/pkg/app/master/commands/build/prompt.go
@@ -77,6 +77,7 @@ var CommandFlagSuggestions = &commands.FlagSuggestions{
 		{Text: commands.FullFlagName(commands.FlagCmd), Description: commands.FlagCmdUsage},
 		{Text: commands.FullFlagName(commands.FlagWorkdir), Description: commands.FlagWorkdirUsage},
 		{Text: commands.FullFlagName(commands.FlagEnv), Description: commands.FlagEnvUsage},
+		{Text: commands.FullFlagName(commands.FlagEnvFile), Description: commands.FlagEnvFileUsage},
 		{Text: commands.FullFlagName(commands.FlagLabel), Description: commands.FlagLabelUsage},
 		{Text: commands.FullFlagName(commands.FlagVolume), Description: commands.FlagVolumeUsage},
 		{Text: commands.FullFlagName(commands.FlagLink), Description: commands.FlagLinkUsage},

--- a/pkg/app/master/commands/cliflags.go
+++ b/pkg/app/master/commands/cliflags.go
@@ -153,6 +153,7 @@ const (
 	FlagCmd                = "cmd"
 	FlagWorkdir            = "workdir"
 	FlagEnv                = "env"
+	FlagEnvFile            = "env-file"
 	FlagLabel              = "label"
 	FlagVolume             = "volume"
 	FlagExpose             = "expose"
@@ -262,6 +263,7 @@ const (
 	FlagCmdUsage                = "Override CMD analyzing image at runtime. To persist CMD changes in the output image, pass the --image-overrides=cmd or --image-overrides=all flag as well."
 	FlagWorkdirUsage            = "Override WORKDIR analyzing image at runtime. To persist WORKDIR changes in the output image, pass the --image-overrides=workdir or --image-overrides=all flag as well."
 	FlagEnvUsage                = "Override or add ENV only during runtime. To persist ENV additions or changes in the output image, pass the --image-overrides=env or --image-overrides=all flag as well."
+	FlagEnvFileUsage            = "File to override or add ENV only during runtime. To persist ENV additions or changes in the output image, pass the --image-overrides=env or --image-overrides=all flag as well."
 	FlagLabelUsage              = "Override or add LABEL analyzing image at runtime. To persist LABEL additions or changes in the output image, pass the --image-overrides=label or --image-overrides=all flag as well."
 	FlagVolumeUsage             = "Add VOLUME analyzing image at runtime. To persist VOLUME additions in the output image, pass the --image-overrides=volume or --image-overrides=all flag as well."
 	FlagExposeUsage             = "Use additional EXPOSE instructions analyzing image at runtime. To persist EXPOSE additions in the output image, pass the --image-overrides=expose or --image-overrides=all flag as well."
@@ -806,6 +808,12 @@ var CommonFlags = map[string]cli.Flag{
 		Value:   cli.NewStringSlice(),
 		Usage:   FlagEnvUsage,
 		EnvVars: []string{"DSLIM_RC_ENV"},
+	},
+	FlagEnvFile: &cli.StringFlag{
+		Name:    FlagEnvFile,
+		Value:   "",
+		Usage:   FlagEnvFileUsage,
+		EnvVars: []string{"DSLIM_RC_ENV_FILE"},
 	},
 	FlagLabel: &cli.StringSliceFlag{
 		Name:    FlagLabel,

--- a/pkg/app/master/commands/clifvgetter.go
+++ b/pkg/app/master/commands/clifvgetter.go
@@ -234,6 +234,12 @@ func GetContainerOverrides(ctx *cli.Context) (*config.ContainerOverrides, error)
 
 	volumesList := ctx.StringSlice(FlagVolume)
 	labelsList := ctx.StringSlice(FlagLabel)
+	envList, envErr := ParseEnvFile(ctx.String(FlagEnvFile))
+	if envErr != nil {
+		return nil, envErr
+	}
+	env := ctx.StringSlice(FlagEnv)
+	envList = append(envList, env...)
 
 	overrides := &config.ContainerOverrides{
 		User:     ctx.String(FlagUser),

--- a/pkg/app/master/commands/clifvparser.go
+++ b/pkg/app/master/commands/clifvparser.go
@@ -14,7 +14,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/docker/go-connections/nat"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/google/shlex"
 	log "github.com/sirupsen/logrus"
 
@@ -846,4 +846,42 @@ func IsTrueStr(value string) bool {
 	}
 
 	return false
+}
+
+func ParseEnvFile(filePath string) ([]string, error) {
+	var output []string
+
+	if filePath == "" {
+		return output, nil
+	}
+
+	fullPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return output, err
+	}
+	_, err = os.Stat(fullPath)
+	if err != nil {
+		return output, err
+	}
+
+	fileData, err := os.ReadFile(fullPath)
+	if err != nil {
+		return output, err
+	}
+
+	if len(fileData) == 0 {
+		return output, nil
+	}
+
+	lines := strings.Split(string(fileData), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if len(line) > 0 {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				output = append(output, line)
+			}
+		}
+	}
+	return output, nil
 }

--- a/pkg/app/master/commands/profile/cli.go
+++ b/pkg/app/master/commands/profile/cli.go
@@ -65,6 +65,7 @@ var CLI = &cli.Command{
 		commands.Cflag(commands.FlagCmd),
 		commands.Cflag(commands.FlagWorkdir),
 		commands.Cflag(commands.FlagEnv),
+		commands.Cflag(commands.FlagEnvFile),
 		commands.Cflag(commands.FlagLabel),
 		commands.Cflag(commands.FlagVolume),
 		commands.Cflag(commands.FlagLink),

--- a/pkg/app/master/commands/profile/prompt.go
+++ b/pkg/app/master/commands/profile/prompt.go
@@ -51,6 +51,7 @@ var CommandFlagSuggestions = &commands.FlagSuggestions{
 		{Text: commands.FullFlagName(commands.FlagCmd), Description: commands.FlagCmdUsage},
 		{Text: commands.FullFlagName(commands.FlagWorkdir), Description: commands.FlagWorkdirUsage},
 		{Text: commands.FullFlagName(commands.FlagEnv), Description: commands.FlagEnvUsage},
+		{Text: commands.FullFlagName(commands.FlagEnvFile), Description: commands.FlagEnvFileUsage},
 		{Text: commands.FullFlagName(commands.FlagLabel), Description: commands.FlagLabelUsage},
 		{Text: commands.FullFlagName(commands.FlagVolume), Description: commands.FlagVolumeUsage},
 		{Text: commands.FullFlagName(commands.FlagLink), Description: commands.FlagLinkUsage},


### PR DESCRIPTION
[Fixes-560](https://github.com/docker-slim/docker-slim/issues/560)
==================================================================

What
===============
Add --env-file flag to build and profile command to allow passing multiple env key/value data

Why
===============


How Tested
===============


