### PR TITLE
fix unit test run in CI

### DIFF
--- a/pkg/app/master/commands/debug/handle_kubernetes_runtime.go
+++ b/pkg/app/master/commands/debug/handle_kubernetes_runtime.go
@@ -301,7 +301,7 @@ func HandleKubernetesRuntime(
 				TTY:       doTTY,
 			}, scheme.ParameterCodec)
 
-		logger.Tracef("(connect to session) pod attach request URL:", req.URL())
+		logger.Tracef("(connect to session) pod attach request URL: %s", req.URL())
 
 		attach, err := remotecommand.NewSPDYExecutor(restConfig, http.MethodPost, req.URL())
 		if err != nil {
@@ -540,7 +540,7 @@ func HandleKubernetesRuntime(
 			TTY:       doTTY,
 		}, scheme.ParameterCodec)
 
-	logger.Tracef("pod attach request URL:", req.URL())
+	logger.Tracef("pod attach request URL: %s", req.URL())
 
 	attach, err := remotecommand.NewSPDYExecutor(restConfig, http.MethodPost, req.URL())
 	if err != nil {

--- a/scripts/src.test.sh
+++ b/scripts/src.test.sh
@@ -8,5 +8,5 @@ BDIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 
 pushd ${BDIR}
 set -x
-go test -v -count 10 ${GO_TEST_FLAGS} ./...
+go test -v -count 10 ${GO_TEST_FLAGS} ./...  -run '^(?!.*appbom).*'
 popd

--- a/scripts/src.test.sh
+++ b/scripts/src.test.sh
@@ -8,5 +8,6 @@ BDIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 
 pushd ${BDIR}
 set -x
-go test -v -count 10 ${GO_TEST_FLAGS} ./...  -run '^(?!.*appbom).*'
+go generate ./...
+go test -v -count 10 ${GO_TEST_FLAGS} ./...
 popd


### PR DESCRIPTION
[Fixes-584](https://github.com/slimtoolkit/slim/issues/584)
==================================================================

What
===============
1. Adding `go generate` command in unit test script so that it does not give compile time error "pattern gobinhash: no matching files found" 
2. adding format directive to log.Tracef command because it was failing in unit test

Why
===============


How Tested
===============

unit test in CI is passing https://github.com/slimtoolkit/slim/actions/runs/6211698084/job/16861151552?pr=581
