### PR TITLE
[feat] Standalone control commands

### DIFF
--- a/pkg/app/sensor/app_test.go
+++ b/pkg/app/sensor/app_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/docker-slim/docker-slim/pkg/app/sensor/standalone/control"
 	"github.com/docker-slim/docker-slim/pkg/ipc/event"
 	"github.com/docker-slim/docker-slim/pkg/report"
 	testsensor "github.com/docker-slim/docker-slim/pkg/test/e2e/sensor"
@@ -556,4 +557,22 @@ func TestArchiveArtifacts_SensorFailure_NoCaps(t *testing.T) {
 func TestArchiveArtifacts_SensorFailure_NoRoot(t *testing.T) {
 	// It's a fairly common failure scenario.
 	t.Skip("Implement me!")
+}
+
+func TestControlCommands_StopTargetApp(t *testing.T) {
+	runID := newTestRun(t)
+	ctx := context.Background()
+
+	sensor := testsensor.NewSensorOrFail(t, ctx, t.TempDir(), runID, imageSimpleService)
+	defer sensor.Cleanup(t, ctx)
+
+	sensor.StartStandaloneOrFail(t, ctx, nil)
+
+	go testutil.Delayed(ctx, 5*time.Second, func() {
+		sensor.ExecuteControlCommandOrFail(t, ctx, control.StopTargetAppCommand)
+	})
+
+	sensor.WaitOrFail(t, ctx)
+
+	sensor.AssertSensorLogsContain(t, ctx, sensorFullLifecycleSequence...)
 }

--- a/pkg/app/sensor/execution/standalone.go
+++ b/pkg/app/sensor/execution/standalone.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/docker-slim/docker-slim/pkg/app/sensor/standalone/control"
 	"github.com/docker-slim/docker-slim/pkg/ipc/command"
 	"github.com/docker-slim/docker-slim/pkg/ipc/event"
 	"github.com/docker-slim/docker-slim/pkg/util/fsutil"
@@ -54,8 +55,10 @@ func NewStandalone(
 		)
 	}
 
-	commandCh := make(chan command.Message, 1)
+	commandCh := make(chan command.Message, 10)
 	commandCh <- &cmd
+
+	go control.HandleControlCommandQueue(ctx, commandFileName, commandCh)
 
 	return &standaloneExe{
 		hookExecutor: hookExecutor{

--- a/pkg/app/sensor/standalone/control/commands.go
+++ b/pkg/app/sensor/standalone/control/commands.go
@@ -1,0 +1,7 @@
+package control
+
+type Command string
+
+const (
+	StopTargetAppCommand Command = "stop-target-app"
+)

--- a/pkg/app/sensor/standalone/control/queue.go
+++ b/pkg/app/sensor/standalone/control/queue.go
@@ -1,0 +1,83 @@
+package control
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"syscall"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/docker-slim/docker-slim/pkg/ipc/command"
+)
+
+func HandleControlCommandQueue(ctx context.Context, commandsFile string, commandCh chan command.Message) {
+	fifoPath := getFIFOPath(commandsFile)
+	if !createFIFOIfNeeded(fifoPath) {
+		return
+	}
+	go func() {
+		<-ctx.Done()
+		os.Remove(fifoPath)
+	}()
+
+	processCommandsFromFIFO(ctx, fifoPath, commandCh)
+}
+
+func getFIFOPath(commandsFile string) string {
+	return commandsFile + ".fifo"
+}
+
+func createFIFOIfNeeded(fifoPath string) bool {
+	if _, err := os.Stat(fifoPath); os.IsNotExist(err) {
+		if err = syscall.Mkfifo(fifoPath, 0600); err != nil {
+			log.Warnf("sensor: control commands not activated - cannot create %s FIFO file: %s", fifoPath, err)
+			return false
+		}
+		log.Info("sensor: control commands activated")
+	}
+	return true
+}
+
+func processCommandsFromFIFO(ctx context.Context, fifoPath string, commandCh chan command.Message) {
+	for ctx.Err() == nil {
+		fifo, err := os.Open(fifoPath)
+		if err != nil {
+			log.Debugf("sensor: control commands - cannot open %s FIFO file: %s", fifoPath, err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		readAndHandleCommands(fifo, commandCh)
+		fifo.Close()
+	}
+}
+
+func readAndHandleCommands(fifo *os.File, commandCh chan command.Message) {
+	reader := bufio.NewReader(fifo)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			handleCommand(line, commandCh)
+		}
+
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			log.Warnf("sensor: error reading control command: %s", err)
+			time.Sleep(1 * time.Second)
+		}
+	}
+}
+
+func handleCommand(line []byte, commandCh chan command.Message) {
+	msg, err := command.Decode(line)
+	if err == nil {
+		commandCh <- msg
+	} else {
+		log.Warnf("sensor: cannot decode control command %#q: %s", line, err)
+	}
+}

--- a/pkg/app/sensor/standalone/control/stop.go
+++ b/pkg/app/sensor/standalone/control/stop.go
@@ -1,0 +1,75 @@
+package control
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/docker-slim/docker-slim/pkg/ipc/command"
+	"github.com/docker-slim/docker-slim/pkg/ipc/event"
+	"github.com/docker-slim/docker-slim/pkg/util/fsutil"
+)
+
+func ExecuteStopTargetAppCommand(
+	ctx context.Context,
+	commandsFile string,
+	eventsFile string,
+) error {
+	msg, err := command.Encode(&command.StopMonitor{})
+	if err != nil {
+		return fmt.Errorf("cannot encode stop command: %w", err)
+	}
+
+	if err := fsutil.AppendToFile(getFIFOPath(commandsFile), msg, false); err != nil {
+		return fmt.Errorf("cannot append stop command to FIFO file: %w", err)
+	}
+
+	if err := waitForEvent(ctx, eventsFile, event.StopMonitorDone); err != nil {
+		return fmt.Errorf("waiting for %v event: %w", event.StopMonitorDone, err)
+	}
+
+	return nil
+}
+
+func waitForEvent(ctx context.Context, eventsFile string, target event.Type) error {
+	for ctx.Err() == nil {
+		found, err := findEvent(eventsFile, target)
+		if err != nil {
+			return err
+		}
+
+		if found {
+			return nil
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return ctx.Err()
+}
+
+func findEvent(eventsFile string, target event.Type) (bool, error) {
+	file, err := os.Open(eventsFile)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// A bit hacky - we probably need to parse the event struct properly.
+		if strings.Contains(line, string(target)) {
+			return true, nil
+		}
+	}
+
+	if scanner.Err() != nil {
+		return false, scanner.Err()
+	}
+
+	return false, nil
+}

--- a/pkg/test/e2e/sensor/docker.go
+++ b/pkg/test/e2e/sensor/docker.go
@@ -96,6 +96,12 @@ func containerInspect(ctx context.Context, contID string) (dockerapi.Container, 
 	return conts[0], nil
 }
 
+func containerExec(ctx context.Context, contID string, arg ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "docker", append([]string{"container", "exec", contID}, arg...)...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 func containerLogs(ctx context.Context, contID string) (string, error) {
 	cmd := exec.CommandContext(ctx, "docker", "container", "logs", contID)
 	out, err := cmd.CombinedOutput()

--- a/pkg/test/e2e/sensor/sensor.go
+++ b/pkg/test/e2e/sensor/sensor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker-slim/docker-slim/pkg/app"
 	"github.com/docker-slim/docker-slim/pkg/app/master/inspectors/ipc"
 	"github.com/docker-slim/docker-slim/pkg/app/master/inspectors/sensor"
+	"github.com/docker-slim/docker-slim/pkg/app/sensor/standalone/control"
 	"github.com/docker-slim/docker-slim/pkg/ipc/channel"
 	"github.com/docker-slim/docker-slim/pkg/ipc/command"
 	"github.com/docker-slim/docker-slim/pkg/ipc/event"
@@ -311,6 +312,16 @@ func (s *Sensor) StartStandaloneOrFail(
 }
 
 func (s *Sensor) SendCommand(ctx context.Context, cmd command.Message) error {
+	msg, err := command.Encode(cmd)
+	if err != nil {
+		return fmt.Errorf("cannot encode command %q: %w", cmd, err)
+	}
+	log.Debugf("Sending command to the test sensor: %s", string(msg))
+
+	if len(s.contID) == 0 {
+		return errNotStarted
+	}
+
 	if s.client == nil {
 		return errors.New("IPC client isn't initialized - is sensor running?")
 	}
@@ -349,6 +360,34 @@ func (s *Sensor) SendStopCommand(ctx context.Context) error {
 func (s *Sensor) SendStopCommandOrFail(t *testing.T, ctx context.Context) {
 	if err := s.SendStopCommand(ctx); err != nil {
 		t.Fatal("Failed sending StopMonitor command:", err)
+	}
+}
+
+func (s *Sensor) ExecuteControlCommand(ctx context.Context, cmd control.Command) error {
+	if len(s.contID) == 0 {
+		return errNotStarted
+	}
+
+	if s.client != nil {
+		return fmt.Errorf("cannot execute control command - sensor is not in the standalone mode")
+	}
+
+	if out, err := containerExec(
+		ctx,
+		s.contID,
+		"/opt/_slim/sensor",
+		"control",
+		string(cmd),
+	); err != nil {
+		return fmt.Errorf("cannot execute control command: %w\n%s", err, string(out))
+	}
+
+	return nil
+}
+
+func (s *Sensor) ExecuteControlCommandOrFail(t *testing.T, ctx context.Context, cmd control.Command) {
+	if err := s.ExecuteControlCommand(ctx, cmd); err != nil {
+		t.Fatalf("Failed executing control command %s: %v", cmd, err)
 	}
 }
 


### PR DESCRIPTION
To control sensor execution when running in the standalone mode. This PR ships the machinery and the very first command:

```
/opt/_slim/sensor control stop-target-app
```

The command writes to the `commands` FIFO file and then waits for the `StopMonitorDone` event to show up in the `events` file.
