### PR TITLE
Specify all command parameters in a json (#597)

### DIFF
--- a/pkg/app/master/commands/build/cli.go
+++ b/pkg/app/master/commands/build/cli.go
@@ -32,6 +32,7 @@ var CLI = &cli.Command{
 		commands.Cflag(commands.FlagRegistryAccount),
 		commands.Cflag(commands.FlagRegistrySecret),
 		commands.Cflag(commands.FlagShowPullLogs),
+		commands.Cflag(commands.FlagCommandParamsFile),
 
 		commands.Cflag(commands.FlagComposeFile),
 		commands.Cflag(commands.FlagTargetComposeSvc),
@@ -167,6 +168,7 @@ var CLI = &cli.Command{
 		commands.Cflag(commands.FlagSensorIPCEndpoint),
 		commands.Cflag(commands.FlagSensorIPCMode),
 	}, commands.HTTPProbeFlags()...),
+	Before: commands.LoadParamsFromFile,
 	Action: func(ctx *cli.Context) error {
 		xc := app.NewExecutionContext(Name, ctx.String(commands.FlagConsoleFormat))
 

--- a/pkg/app/master/commands/cliflags.go
+++ b/pkg/app/master/commands/cliflags.go
@@ -52,12 +52,13 @@ const (
 
 // Shared command flag names
 const (
-	FlagTarget           = "target"
-	FlagPull             = "pull"
-	FlagDockerConfigPath = "docker-config-path"
-	FlagRegistryAccount  = "registry-account"
-	FlagRegistrySecret   = "registry-secret"
-	FlagShowPullLogs     = "show-plogs"
+	FlagTarget            = "target"
+	FlagPull              = "pull"
+	FlagDockerConfigPath  = "docker-config-path"
+	FlagRegistryAccount   = "registry-account"
+	FlagRegistrySecret    = "registry-secret"
+	FlagShowPullLogs      = "show-plogs"
+	FlagCommandParamsFile = "command-params-file"
 
 	//Compose-related flags
 	FlagComposeFile                    = "compose-file"
@@ -170,12 +171,13 @@ const (
 
 // Shared command flag usage info
 const (
-	FlagTargetUsage           = "Target container image (name or ID)"
-	FlagPullUsage             = "Try pulling target if it's not available locally"
-	FlagDockerConfigPathUsage = "Docker config path (used to fetch registry credentials)"
-	FlagRegistryAccountUsage  = "Target registry account used when pulling images from private registries"
-	FlagRegistrySecretUsage   = "Target registry secret used when pulling images from private registries"
-	FlagShowPullLogsUsage     = "Show image pull logs"
+	FlagTargetUsage            = "Target container image (name or ID)"
+	FlagPullUsage              = "Try pulling target if it's not available locally"
+	FlagDockerConfigPathUsage  = "Docker config path (used to fetch registry credentials)"
+	FlagRegistryAccountUsage   = "Target registry account used when pulling images from private registries"
+	FlagRegistrySecretUsage    = "Target registry secret used when pulling images from private registries"
+	FlagShowPullLogsUsage      = "Show image pull logs"
+	FlagCommandParamsFileUsage = "File with command parameters (JSON format)"
 
 	//Compose-related flags
 	FlagComposeFileUsage                    = "Load container info from selected compose file(s)"
@@ -394,6 +396,11 @@ var CommonFlags = map[string]cli.Flag{
 		Name:    FlagShowPullLogs,
 		Usage:   FlagShowPullLogsUsage,
 		EnvVars: []string{"DSLIM_PLOG"},
+	},
+	FlagCommandParamsFile: &cli.StringFlag{
+		Name:    FlagCommandParamsFile,
+		Usage:   FlagCommandParamsFileUsage,
+		EnvVars: []string{"DSLIM_COMMAND_PARAMS_FILE"},
 	},
 	//
 	FlagComposeFile: &cli.StringSliceFlag{

--- a/pkg/app/master/commands/common.go
+++ b/pkg/app/master/commands/common.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -258,6 +259,33 @@ func RunHostExecProbes(printState bool, xc *app.ExecutionContext, hostExecProbes
 			}
 		}
 	}
+}
+
+func LoadParamsFromFile(c *cli.Context) error {
+	filePath := c.String(FlagCommandParamsFile)
+	if filePath == "" {
+		return nil
+	}
+
+	fileContent, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Errorf("LoadParamsFromFile(%s): error reading file: %v", filePath, err)
+		return err
+	}
+
+	var params map[string]interface{}
+	err = json.Unmarshal(fileContent, &params)
+	if err != nil {
+		log.Errorf("LoadParamsFromFile(%s): error parsing file: %v", filePath, err)
+		return err
+	}
+
+	for key, value := range params {
+		log.Debug("LoadParamsFromFile(): setting key=", key, " value=", value)
+		c.Set(key, value.(string))
+	}
+
+	return nil
 }
 
 func exeAppCall(appCall string) error {

--- a/pkg/app/master/commands/debug/cli.go
+++ b/pkg/app/master/commands/debug/cli.go
@@ -95,6 +95,7 @@ var CLI = &cli.Command{
 	Aliases: []string{Alias},
 	Usage:   Usage,
 	Flags: []cli.Flag{
+		commands.Cflag(commands.FlagCommandParamsFile),
 		cflag(FlagRuntime),
 		cflag(FlagTarget),
 		cflag(FlagNamespace),
@@ -116,6 +117,7 @@ var CLI = &cli.Command{
 		cflag(FlagListDebugImage),
 		cflag(FlagKubeconfig),
 	},
+	Before: commands.LoadParamsFromFile,
 	Action: func(ctx *cli.Context) error {
 		xc := app.NewExecutionContext(Name, ctx.String(commands.FlagConsoleFormat))
 

--- a/pkg/app/master/commands/lint/cli.go
+++ b/pkg/app/master/commands/lint/cli.go
@@ -18,6 +18,7 @@ var CLI = &cli.Command{
 	Aliases: []string{Alias},
 	Usage:   Usage,
 	Flags: []cli.Flag{
+		commands.Cflag(commands.FlagCommandParamsFile),
 		cflag(commands.FlagTarget),
 		cflag(FlagTargetType),
 		cflag(FlagSkipBuildContext),
@@ -33,6 +34,7 @@ var CLI = &cli.Command{
 		cflag(FlagShowSnippet),
 		cflag(FlagListChecks),
 	},
+	Before: commands.LoadParamsFromFile,
 	Action: func(ctx *cli.Context) error {
 		xc := app.NewExecutionContext(Name, ctx.String(commands.FlagConsoleFormat))
 

--- a/pkg/app/master/commands/merge/cli.go
+++ b/pkg/app/master/commands/merge/cli.go
@@ -22,10 +22,12 @@ var CLI = &cli.Command{
 	Aliases: []string{Alias},
 	Usage:   Usage,
 	Flags: []cli.Flag{
+		commands.Cflag(commands.FlagCommandParamsFile),
 		cflag(FlagImage),
 		cflag(FlagUseLastImageMetadata),
 		cflag(FlagTag),
 	},
+	Before: commands.LoadParamsFromFile,
 	Action: func(ctx *cli.Context) error {
 		if ctx.Args().Len() < 1 {
 			fmt.Printf("slim[%s]: missing target info...\n\n", Name)

--- a/pkg/app/master/commands/registry/cli.go
+++ b/pkg/app/master/commands/registry/cli.go
@@ -44,12 +44,14 @@ var CLI = &cli.Command{
 	Name:    Name,
 	Aliases: []string{Alias},
 	Usage:   Usage,
+	Before:  commands.LoadParamsFromFile,
 	Subcommands: []*cli.Command{
 		{
 			Name:  PullCmdName,
 			Usage: PullCmdNameUsage,
 			Flags: []cli.Flag{
 				commands.Cflag(commands.FlagTarget),
+				commands.Cflag(commands.FlagCommandParamsFile),
 				cflag(FlagSaveToDocker),
 			},
 			Action: func(ctx *cli.Context) error {

--- a/pkg/app/master/commands/run/cli.go
+++ b/pkg/app/master/commands/run/cli.go
@@ -98,6 +98,7 @@ var CLI = &cli.Command{
 		cflag(FlagRemove),
 		cflag(FlagDetach),
 	},
+	Before: commands.LoadParamsFromFile,
 	Action: func(ctx *cli.Context) error {
 		xc := app.NewExecutionContext(Name, ctx.String(commands.FlagConsoleFormat))
 

--- a/pkg/app/master/commands/xray/cli.go
+++ b/pkg/app/master/commands/xray/cli.go
@@ -29,6 +29,7 @@ var CLI = &cli.Command{
 		commands.Cflag(commands.FlagRegistryAccount),
 		commands.Cflag(commands.FlagRegistrySecret),
 		commands.Cflag(commands.FlagShowPullLogs),
+		commands.Cflag(commands.FlagCommandParamsFile),
 		cflag(FlagChanges),
 		cflag(FlagChangesOutput),
 		cflag(FlagLayer),
@@ -55,6 +56,7 @@ var CLI = &cli.Command{
 		cflag(FlagExportAllDataArtifacts),
 		commands.Cflag(commands.FlagRemoveFileArtifacts),
 	},
+	Before: commands.LoadParamsFromFile,
 	Action: func(ctx *cli.Context) error {
 		xc := app.NewExecutionContext(Name, ctx.String(commands.FlagConsoleFormat))
 


### PR DESCRIPTION
This commit introduces a new flag `FlagCommandParamsFile` across multiple command files, allowing parameters to be loaded from a specified file.

The `LoadParamsFromFile` function has been defined to handle file reading and parameter setting. Additionally, code comments and formatting have been updated for improved readability.

This enhancement provides a more flexible and organized way to handle command parameters, especially in cases with numerous or complex parameter sets.
