### PR TITLE
fix: stop signal handling after receiving sensor stop control command

### DIFF
--- a/pkg/app/sensor/controlled/controlled.go
+++ b/pkg/app/sensor/controlled/controlled.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -138,9 +137,6 @@ func (s *Sensor) startMonitor(cmd *command.StartMonitor) (monitor.CompositeMonit
 		s.artifactor.ArtifactsDir(),
 		s.mountPoint,
 		origPaths,
-		// TODO: Do we need to forward signals to the target app in the controlled mode?
-		//       Sounds like a good idea but will change the historical behavior.
-		make(chan os.Signal),
 	)
 	if err != nil {
 		log.WithError(err).Error("sensor: failed to create composite monitor")

--- a/pkg/app/sensor/controlled/controlled_test.go
+++ b/pkg/app/sensor/controlled/controlled_test.go
@@ -3,7 +3,6 @@ package controlled_test
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -40,12 +39,12 @@ func newStubMonitorFunc(
 		artifactsDir string,
 		mountPoint string,
 		origPaths map[string]struct{},
-		signalCh <-chan os.Signal,
 	) (monitor.CompositeMonitor, error) {
 		return monitor.Compose(
 			cmd,
 			fanMon,
 			ptMon,
+			nil,
 			nil,
 		), nil
 	}

--- a/test/e2e-tests.mk
+++ b/test/e2e-tests.mk
@@ -6,7 +6,7 @@ GO_TEST_FLAGS =  # E.g.: make test-e2e-sensor GO_TEST_FLAGS='-run TestXyz'
 # run sensor only e2e tests
 test-e2e-sensor:
 	go generate github.com/docker-slim/docker-slim/pkg/appbom
-	go test -v -tags e2e -count 10 -timeout 30m $(GO_TEST_FLAGS) $(CURDIR)/pkg/app/sensor
+	go test -v -tags e2e -count 5 -timeout 30m $(GO_TEST_FLAGS) $(CURDIR)/pkg/app/sensor
 
 # run all e2e tests at once
 .PHONY:


### PR DESCRIPTION
In the standalone mode, the target app can be done before the stop signal is received because of two reasons:

- App terminated on its own (e.g., a typical CLI use case)
- The "stop monitor" control command was received.

In the latter case, the sensor needs to wait for the stop signal before proceeding with the shutdown because otherwise, the container runtime may restart the container, which is not desirable.

