### PR TITLE
New sensor shutdown sequence

### DIFF
--- a/pkg/app/sensor/app_test.go
+++ b/pkg/app/sensor/app_test.go
@@ -615,7 +615,10 @@ func TestControlCommands_StopTargetApp(t *testing.T) {
 
 	go testutil.Delayed(ctx, 5*time.Second, func() {
 		sensor.ExecuteControlCommandOrFail(t, ctx, control.StopTargetAppCommand)
-		// In the real world, there will be some time between
+		sensor.WaitForEventOrFail(t, ctx, event.StopMonitorDone)
+		sensor.WaitForEventOrFail(t, ctx, event.ShutdownSensorDone)
+
+		// In the real world, there might be some (long) time between
 		// the stop command and the target app signalling - maybe
 		// we need to simulate that here?
 		sensor.SignalOrFail(t, ctx, syscall.SIGQUIT)

--- a/pkg/app/sensor/controlled/controlled.go
+++ b/pkg/app/sensor/controlled/controlled.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker-slim/docker-slim/pkg/ipc/command"
 	"github.com/docker-slim/docker-slim/pkg/ipc/event"
 	"github.com/docker-slim/docker-slim/pkg/mondel"
+	"github.com/docker-slim/docker-slim/pkg/util/errutil"
 )
 
 var ErrPrematureShutdown = errors.New("sensor shutdown before monitor stop")
@@ -62,6 +63,24 @@ func NewSensor(
 //     -> ShutdownSensor command arrives => cancel monitoring, grumble, and exit
 //     -> Any other command              => grumble but keep waiting
 func (s *Sensor) Run() error {
+	s.exe.HookSensorPostStart()
+
+	err := s.run()
+	if err != nil {
+		s.exe.PubEvent(event.Error, err.Error())
+	}
+
+	// We have to dump the artifacts before invokin the pre-shutdown
+	// hook - it may want to upload the artifacts somewhere.
+	errutil.WarnOn(s.artifactor.Archive())
+
+	s.exe.HookSensorPreShutdown()
+	s.exe.PubEvent(event.ShutdownSensorDone)
+
+	return err
+}
+
+func (s *Sensor) run() error {
 	log.Info("sensor: waiting for commands...")
 
 	for {
@@ -73,14 +92,12 @@ func (s *Sensor) Run() error {
 		}
 
 		if mon == nil {
-			s.exe.PubEvent(event.ShutdownSensorDone)
 			return nil
 		}
 
 		s.exe.PubEvent(event.StartMonitorDone)
 
 		if err := s.runWithMonitor(mon); err != nil {
-			s.exe.PubEvent(event.ShutdownSensorDone)
 			return fmt.Errorf("run sensor with monitor failed: %w", err)
 		}
 
@@ -229,8 +246,4 @@ func (s *Sensor) processMonitoringResults(mon monitor.CompositeMonitor) error {
 		return fmt.Errorf("saving reports failed: %w", err)
 	}
 	return nil // Clean exit
-}
-
-func nonCriticalError(err error) error {
-	return fmt.Errorf("non-critical monitor error: %w", err)
 }

--- a/pkg/app/sensor/execution/standalone.go
+++ b/pkg/app/sensor/execution/standalone.go
@@ -39,7 +39,7 @@ func NewStandalone(
 		)
 	}
 
-	eventFile, err := os.OpenFile(eventFileName, os.O_APPEND|os.O_WRONLY, 0644)
+	eventFile, err := os.OpenFile(eventFileName, os.O_APPEND|os.O_WRONLY|os.O_SYNC, 0644)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"cannot create execution - open event file %q failed: %w",

--- a/pkg/app/sensor/standalone/control/commands.go
+++ b/pkg/app/sensor/standalone/control/commands.go
@@ -4,4 +4,5 @@ type Command string
 
 const (
 	StopTargetAppCommand Command = "stop-target-app"
+	WaitForEventCommand  Command = "wait-for-event"
 )

--- a/pkg/app/sensor/standalone/control/stop.go
+++ b/pkg/app/sensor/standalone/control/stop.go
@@ -1,23 +1,14 @@
 package control
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/docker-slim/docker-slim/pkg/ipc/command"
-	"github.com/docker-slim/docker-slim/pkg/ipc/event"
 	"github.com/docker-slim/docker-slim/pkg/util/fsutil"
 )
 
-func ExecuteStopTargetAppCommand(
-	ctx context.Context,
-	commandsFile string,
-	eventsFile string,
-) error {
+func ExecuteStopTargetAppCommand(ctx context.Context, commandsFile string) error {
 	msg, err := command.Encode(&command.StopMonitor{})
 	if err != nil {
 		return fmt.Errorf("cannot encode stop command: %w", err)
@@ -27,49 +18,5 @@ func ExecuteStopTargetAppCommand(
 		return fmt.Errorf("cannot append stop command to FIFO file: %w", err)
 	}
 
-	if err := waitForEvent(ctx, eventsFile, event.StopMonitorDone); err != nil {
-		return fmt.Errorf("waiting for %v event: %w", event.StopMonitorDone, err)
-	}
-
 	return nil
-}
-
-func waitForEvent(ctx context.Context, eventsFile string, target event.Type) error {
-	for ctx.Err() == nil {
-		found, err := findEvent(eventsFile, target)
-		if err != nil {
-			return err
-		}
-
-		if found {
-			return nil
-		}
-
-		time.Sleep(1 * time.Second)
-	}
-
-	return ctx.Err()
-}
-
-func findEvent(eventsFile string, target event.Type) (bool, error) {
-	file, err := os.Open(eventsFile)
-	if err != nil {
-		return false, err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		// A bit hacky - we probably need to parse the event struct properly.
-		if strings.Contains(line, string(target)) {
-			return true, nil
-		}
-	}
-
-	if scanner.Err() != nil {
-		return false, scanner.Err()
-	}
-
-	return false, nil
 }

--- a/pkg/app/sensor/standalone/control/wait.go
+++ b/pkg/app/sensor/standalone/control/wait.go
@@ -1,0 +1,64 @@
+package control
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/docker-slim/docker-slim/pkg/ipc/event"
+)
+
+func ExecuteWaitEvenCommand(
+	ctx context.Context,
+	eventsFile string,
+	evt event.Type,
+) error {
+	if err := waitForEvent(ctx, eventsFile, evt); err != nil {
+		return fmt.Errorf("waiting for %v event: %w", evt, err)
+	}
+
+	return nil
+}
+
+func waitForEvent(ctx context.Context, eventsFile string, target event.Type) error {
+	for ctx.Err() == nil {
+		found, err := findEvent(eventsFile, target)
+		if err != nil {
+			return err
+		}
+
+		if found {
+			return nil
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return ctx.Err()
+}
+
+func findEvent(eventsFile string, target event.Type) (bool, error) {
+	file, err := os.Open(eventsFile)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// A bit hacky - we probably need to parse the event struct properly.
+		if strings.Contains(line, string(target)) {
+			return true, nil
+		}
+	}
+
+	if scanner.Err() != nil {
+		return false, scanner.Err()
+	}
+
+	return false, nil
+}

--- a/pkg/test/e2e/sensor/docker.go
+++ b/pkg/test/e2e/sensor/docker.go
@@ -98,12 +98,18 @@ func containerInspect(ctx context.Context, contID string) (dockerapi.Container, 
 
 func containerExec(ctx context.Context, contID string, arg ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "docker", append([]string{"container", "exec", contID}, arg...)...)
+
+	log.Debug("Executing: ", cmd.String())
+
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }
 
 func containerLogs(ctx context.Context, contID string) (string, error) {
 	cmd := exec.CommandContext(ctx, "docker", "container", "logs", contID)
+
+	log.Debug("Executing: ", cmd.String())
+
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }


### PR DESCRIPTION
A bunch of changes to the sensor shutdown sequence and the (new) control commands:

- A new `sensor control wait-for-event <evt>` command to wait for an arbitrary
  sensor event to show up in the events.json file.
- The sensor now archives artifacts before the "event.sensor.shutdown.done" event.
- The `sensor control stop-target-app` command now doesn't block until
  the target app exits.

The change is needed to work around a deadlock situation caused by the sensor main
loop (blockingly) invoking art_collector, which would also blockingly run the
`sensor control stop-target-app` command, which in turn would become stuck waiting
for the main loop to terminate the target app.

The proposed usage now looks like this:

```
<start the instrumented container>
sensor control-stop-target-app                            # non-blocking
sensor control wait-for-event event.sensor.shutdown.done  # optional,blocking
docker stop <instrumented container>                      # or the like
```
