### PR TITLE
feat: 'target-app-running' lifecycle hook

### DIFF
--- a/pkg/app/sensor/controlled/controlled.go
+++ b/pkg/app/sensor/controlled/controlled.go
@@ -174,6 +174,9 @@ func (s *Sensor) runWithMonitor(mon monitor.CompositeMonitor) error {
 	log.Debug("sensor: monitor.worker - waiting to stop monitoring...")
 	log.Debug("sensor: error collector - waiting for errors...")
 
+	ticker := time.NewTicker(time.Second * 5)
+	defer ticker.Stop()
+
 	// Only two ways out of this: either StopMonitor or ShutdownSensor.
 	stopCommandReceived := false
 
@@ -202,7 +205,8 @@ loop:
 			log.WithError(err).Warn("sensor: non-critical monitor error condition")
 			s.exe.PubEvent(event.Error, monitor.NonCriticalError(err).Error())
 
-		case <-time.After(time.Second * 5):
+		case <-ticker.C:
+			s.exe.HookTargetAppRunning()
 			log.Debug(".")
 		} // eof: select
 	}

--- a/pkg/app/sensor/execution/hook.go
+++ b/pkg/app/sensor/execution/hook.go
@@ -14,6 +14,7 @@ const (
 	sensorPostStart     kind = "sensor-post-start"
 	sensorPreShutdown   kind = "sensor-pre-shutdown"
 	monitorPreStart     kind = "monitor-pre-start"
+	targetAppRunning    kind = "target-app-running"
 	monitorPostShutdown kind = "monitor-post-shutdown"
 	monitorFailed       kind = "monitor-failed"
 )
@@ -33,6 +34,10 @@ func (h *hookExecutor) HookSensorPreShutdown() {
 
 func (h *hookExecutor) HookMonitorPreStart() {
 	h.doHook(monitorPreStart)
+}
+
+func (h *hookExecutor) HookTargetAppRunning() {
+	h.doHook(targetAppRunning)
 }
 
 func (h *hookExecutor) HookMonitorPostShutdown() {

--- a/pkg/app/sensor/execution/interface.go
+++ b/pkg/app/sensor/execution/interface.go
@@ -14,6 +14,7 @@ type Interface interface {
 	HookSensorPostStart()
 	HookSensorPreShutdown()
 	HookMonitorPreStart()
+	HookTargetAppRunning()
 	HookMonitorPostShutdown()
 	HookMonitorFailed()
 }

--- a/pkg/app/sensor/standalone/standalone.go
+++ b/pkg/app/sensor/standalone/standalone.go
@@ -199,6 +199,7 @@ loop:
 			s.exe.PubEvent(event.Error, monitor.NonCriticalError(err).Error())
 
 		case <-ticker.C:
+			s.exe.HookTargetAppRunning()
 			log.Debug(".")
 		}
 

--- a/pkg/test/stub/sensor/execution/execution.go
+++ b/pkg/test/stub/sensor/execution/execution.go
@@ -51,6 +51,10 @@ func (e *executionStub) HookMonitorPreStart() {
 	// noop
 }
 
+func (e *executionStub) HookTargetAppRunning() {
+	// noop
+}
+
 func (e *executionStub) HookMonitorPostShutdown() {
 	// noop
 }


### PR DESCRIPTION
The hook is invoked every 5 seconds while the target app is being traced. This hook is going to be used by the art_collector to check if the instrumented run needs to be stopped.