### PR TITLE
[feat] Implement `registry server` subcommand

### DIFF
--- a/pkg/app/master/command/registry/cli.go
+++ b/pkg/app/master/command/registry/cli.go
@@ -25,6 +25,9 @@ const (
 
 	ImageIndexCreateCmdName      = "image-index-create"
 	ImageIndexCreateCmdNameUsage = "Create an image index (aka manifest list) with the referenced images (already in the target registry)"
+
+	ServerCmdName      = "server"
+	ServerCmdNameUsage = "Start a registry server"
 )
 
 func fullCmdName(subCmdName string) string {
@@ -91,6 +94,25 @@ func ImageIndexCreateCommandFlagValues(ctx *cli.Context) (*ImageIndexCreateComma
 		AsManifestList:      ctx.Bool(FlagAsManifestList),
 		InsecureRefs:        ctx.Bool(FlagInsecureRefs),
 		DumpRawManifest:     ctx.Bool(FlagDumpRawManifest),
+	}
+
+	return values, nil
+}
+
+type ServerCommandParams struct {
+	*CommonCommandParams
+	EnableReferrersAPI bool
+}
+
+func ServerCommandFlagValues(ctx *cli.Context) (*ServerCommandParams, error) {
+	common, err := CommonCommandFlagValues(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	values := &ServerCommandParams{
+		CommonCommandParams: common,
+		EnableReferrersAPI:  ctx.Bool(FlagEnableReferrersAPI),
 	}
 
 	return values, nil
@@ -191,6 +213,25 @@ var CLI = &cli.Command{
 
 				xc := app.NewExecutionContext(fullCmdName(ImageIndexCreateCmdName), ctx.String(command.FlagConsoleFormat))
 				OnImageIndexCreateCommand(xc, gcvalues, cparams)
+				return nil
+			},
+		},
+		{
+			Name:  ServerCmdName,
+			Usage: ServerCmdNameUsage,
+			Action: func(ctx *cli.Context) error {
+				gcvalues, err := command.GlobalFlagValues(ctx)
+				if err != nil {
+					return err
+				}
+
+				cparams, err := ServerCommandFlagValues(ctx)
+				if err != nil {
+					return err
+				}
+
+				xc := app.NewExecutionContext(fullCmdName(ServerCmdName), ctx.String(command.FlagConsoleFormat))
+				OnServerCommand(xc, gcvalues, cparams)
 				return nil
 			},
 		},

--- a/pkg/app/master/command/registry/flags.go
+++ b/pkg/app/master/command/registry/flags.go
@@ -7,28 +7,30 @@ import (
 
 // Registry command flag names
 const (
-	FlagUseDockerCreds  = "use-docker-credentials"
-	FlagCredsAccount    = "account"
-	FlagCredsSecret     = "secret"
-	FlagSaveToDocker    = "save-to-docker"
-	FlagImageIndexName  = "image-index-name"
-	FlagImageName       = "image-name"
-	FlagAsManifestList  = "as-manifest-list"
-	FlagInsecureRefs    = "insecure-refs"
-	FlagDumpRawManifest = "dump-raw-manifest"
+	FlagUseDockerCreds     = "use-docker-credentials"
+	FlagCredsAccount       = "account"
+	FlagCredsSecret        = "secret"
+	FlagSaveToDocker       = "save-to-docker"
+	FlagImageIndexName     = "image-index-name"
+	FlagImageName          = "image-name"
+	FlagAsManifestList     = "as-manifest-list"
+	FlagInsecureRefs       = "insecure-refs"
+	FlagDumpRawManifest    = "dump-raw-manifest"
+	FlagEnableReferrersAPI = "with-referrer-api"
 )
 
 // Registry command flag usage info
 const (
-	FlagUseDockerCredsUsage  = "Use the registry credentials from the default Docker config file"
-	FlagCredsAccountUsage    = "Registry credentials account"
-	FlagCredsSecretUsage     = "Registry credentials secret"
-	FlagSaveToDockerUsage    = "Save pulled image to docker"
-	FlagImageIndexNameUsage  = "Image index name to use"
-	FlagImageNameUsage       = "Target image name to include in image index"
-	FlagAsManifestListUsage  = "Create image index with the manifest list media type instead of the default OCI image index type"
-	FlagInsecureRefsUsage    = "Allow the referenced images from insecure registry connections"
-	FlagDumpRawManifestUsage = "Dump raw manifest for the created image index"
+	FlagUseDockerCredsUsage     = "Use the registry credentials from the default Docker config file"
+	FlagCredsAccountUsage       = "Registry credentials account"
+	FlagCredsSecretUsage        = "Registry credentials secret"
+	FlagSaveToDockerUsage       = "Save pulled image to docker"
+	FlagImageIndexNameUsage     = "Image index name to use"
+	FlagImageNameUsage          = "Target image name to include in image index"
+	FlagAsManifestListUsage     = "Create image index with the manifest list media type instead of the default OCI image index type"
+	FlagInsecureRefsUsage       = "Allow the referenced images from insecure registry connections"
+	FlagDumpRawManifestUsage    = "Dump raw manifest for the created image index"
+	FlagEnableReferrersAPIUsage = "Enables the referrers API endpoint (OCI 1.1+) for the registry server"
 )
 
 var Flags = map[string]cli.Flag{
@@ -85,6 +87,12 @@ var Flags = map[string]cli.Flag{
 		Value:   false, //defaults to false
 		Usage:   FlagDumpRawManifestUsage,
 		EnvVars: []string{"DSLIM_REG_IIC_DUMP_MANIFEST"},
+	},
+	FlagEnableReferrersAPI: &cli.BoolFlag{
+		Name:    FlagEnableReferrersAPI,
+		Value:   false, //defaults to false
+		Usage:   FlagEnableReferrersAPIUsage,
+		EnvVars: []string{"DSLIM_REG_ENABLE_REFERRERS_API"},
 	},
 }
 

--- a/pkg/app/master/command/registry/handler_server.go
+++ b/pkg/app/master/command/registry/handler_server.go
@@ -24,11 +24,11 @@ func OnServerCommand(
 	xc *app.ExecutionContext,
 	gparams *command.GenericParams,
 	cparams *ServerCommandParams) {
-	cmdName := fullCmdName(PushCmdName)
+	cmdName := fullCmdName(ServerCmdName)
 	logger := log.WithFields(log.Fields{
 		"app": appName,
 		"cmd": cmdName,
-		"sub": PushCmdName})
+		"sub": ServerCmdName})
 
 	viChan := version.CheckAsync(gparams.CheckVersion, gparams.InContainer, gparams.IsDSImage)
 
@@ -69,13 +69,10 @@ func OnServerCommand(
 		opts = append(opts, registry.WithReferrersSupport(true))
 	}
 
-	err = http.ListenAndServe(":5000", registry.New(opts...))
-	errutil.FailOn(err)
+	xc.Out.Message("Starting registry server on port 5000")
 
-	xc.Out.Info("registry.server",
-		ovars{
-			"url": "http://localhost:5000/",
-		})
+	err = http.ListenAndServe("127.0.0.1:5000", registry.New(opts...))
+	errutil.FailOn(err)
 
 	xc.Out.State(cmd.StateCompleted)
 	cmdReport.State = cmd.StateCompleted

--- a/pkg/app/master/command/registry/handler_server.go
+++ b/pkg/app/master/command/registry/handler_server.go
@@ -1,0 +1,94 @@
+package registry
+
+import (
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+
+	stdlog "log"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/slimtoolkit/slim/pkg/app"
+	"github.com/slimtoolkit/slim/pkg/app/master/command"
+	"github.com/slimtoolkit/slim/pkg/app/master/version"
+	cmd "github.com/slimtoolkit/slim/pkg/command"
+	"github.com/slimtoolkit/slim/pkg/docker/dockerclient"
+	"github.com/slimtoolkit/slim/pkg/report"
+	"github.com/slimtoolkit/slim/pkg/util/errutil"
+	"github.com/slimtoolkit/slim/pkg/util/fsutil"
+	v "github.com/slimtoolkit/slim/pkg/version"
+)
+
+// OnServerCommand implements the 'registry server' command
+func OnServerCommand(
+	xc *app.ExecutionContext,
+	gparams *command.GenericParams,
+	cparams *ServerCommandParams) {
+	cmdName := fullCmdName(PushCmdName)
+	logger := log.WithFields(log.Fields{
+		"app": appName,
+		"cmd": cmdName,
+		"sub": PushCmdName})
+
+	viChan := version.CheckAsync(gparams.CheckVersion, gparams.InContainer, gparams.IsDSImage)
+
+	cmdReport := report.NewRegistryCommand(gparams.ReportLocation, gparams.InContainer)
+	cmdReport.State = cmd.StateStarted
+
+	xc.Out.State(cmd.StateStarted)
+
+	client, err := dockerclient.New(gparams.ClientConfig)
+	if err == dockerclient.ErrNoDockerInfo {
+		exitMsg := "missing Docker connection info"
+		if gparams.InContainer && gparams.IsDSImage {
+			exitMsg = "make sure to pass the Docker connect parameters to the docker-slim container"
+		}
+
+		xc.Out.Info("docker.connect.error",
+			ovars{
+				"message": exitMsg,
+			})
+
+		exitCode := command.ECTCommon | command.ECCNoDockerConnectInfo
+		xc.Out.State("exited",
+			ovars{
+				"exit.code": exitCode,
+				"version":   v.Current(),
+				"location":  fsutil.ExeDir(),
+			})
+		xc.Exit(exitCode)
+	}
+	errutil.FailOn(err)
+
+	if gparams.Debug {
+		version.Print(xc, cmdName, logger, client, false, gparams.InContainer, gparams.IsDSImage)
+	}
+
+	opts := []registry.Option{registry.Logger(stdlog.New(logger.Logger.Out, "", stdlog.LstdFlags))}
+	if cparams.EnableReferrersAPI {
+		opts = append(opts, registry.WithReferrersSupport(true))
+	}
+
+	err = http.ListenAndServe(":5000", registry.New(opts...))
+	errutil.FailOn(err)
+
+	xc.Out.Info("registry.server",
+		ovars{
+			"url": "http://localhost:5000/",
+		})
+
+	xc.Out.State(cmd.StateCompleted)
+	cmdReport.State = cmd.StateCompleted
+	xc.Out.State(cmd.StateDone)
+
+	vinfo := <-viChan
+	version.PrintCheckVersion(xc, "", vinfo)
+
+	cmdReport.State = cmd.StateDone
+	if cmdReport.Save() {
+		xc.Out.Info("report",
+			ovars{
+				"file": cmdReport.ReportLocation(),
+			})
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/internal/httptest/httptest.go
+++ b/vendor/github.com/google/go-containerregistry/internal/httptest/httptest.go
@@ -1,0 +1,104 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httptest provides a method for testing a TLS server a la net/http/httptest.
+package httptest
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+// NewTLSServer returns an httptest server, with an http client that has been configured to
+// send all requests to the returned server. The TLS certs are generated for the given domain.
+// If you need a transport, Client().Transport is correctly configured.
+func NewTLSServer(domain string, handler http.Handler) (*httptest.Server, error) {
+	s := httptest.NewUnstartedServer(handler)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses: []net.IP{
+			net.IPv4(127, 0, 0, 1),
+			net.IPv6loopback,
+		},
+		DNSNames: []string{domain},
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := &bytes.Buffer{}
+	if err := pem.Encode(pc, &pem.Block{Type: "CERTIFICATE", Bytes: b}); err != nil {
+		return nil, err
+	}
+
+	ek, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, err
+	}
+
+	pk := &bytes.Buffer{}
+	if err := pem.Encode(pk, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ek}); err != nil {
+		return nil, err
+	}
+
+	c, err := tls.X509KeyPair(pc.Bytes(), pk.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	s.TLS = &tls.Config{
+		Certificates: []tls.Certificate{c},
+	}
+	s.StartTLS()
+
+	certpool := x509.NewCertPool()
+	certpool.AddCert(s.Certificate())
+
+	t := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: certpool,
+		},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return net.Dial(s.Listener.Addr().Network(), s.Listener.Addr().String())
+		},
+	}
+	s.Client().Transport = t
+
+	return s, nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/README.md
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/README.md
@@ -1,0 +1,14 @@
+# `pkg/registry`
+
+This package implements a Docker v2 registry and the OCI distribution specification.
+
+It is designed to be used anywhere a low dependency container registry is needed, with an initial focus on tests.
+
+Its goal is to be standards compliant and its strictness will increase over time.
+
+This is currently a low flightmiles system. It's likely quite safe to use in tests; If you're using it in production, please let us know how and send us PRs for integration tests.
+
+Before sending a PR, understand that the expectation of this package is that it remain free of extraneous dependencies.
+This means that we expect `pkg/registry` to only have dependencies on Go's standard library, and other packages in `go-containerregistry`.
+
+You may be asked to change your code to reduce dependencies, and your PR might be rejected if this is deemed impossible.

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/blobs.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/blobs.go
@@ -1,0 +1,485 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/google/go-containerregistry/internal/verify"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// Returns whether this url should be handled by the blob handler
+// This is complicated because blob is indicated by the trailing path, not the leading path.
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pulling-a-layer
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pushing-a-layer
+func isBlob(req *http.Request) bool {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	if elem[len(elem)-1] == "" {
+		elem = elem[:len(elem)-1]
+	}
+	if len(elem) < 3 {
+		return false
+	}
+	return elem[len(elem)-2] == "blobs" || (elem[len(elem)-3] == "blobs" &&
+		elem[len(elem)-2] == "uploads")
+}
+
+// BlobHandler represents a minimal blob storage backend, capable of serving
+// blob contents.
+type BlobHandler interface {
+	// Get gets the blob contents, or errNotFound if the blob wasn't found.
+	Get(ctx context.Context, repo string, h v1.Hash) (io.ReadCloser, error)
+}
+
+// BlobStatHandler is an extension interface representing a blob storage
+// backend that can serve metadata about blobs.
+type BlobStatHandler interface {
+	// Stat returns the size of the blob, or errNotFound if the blob wasn't
+	// found, or redirectError if the blob can be found elsewhere.
+	Stat(ctx context.Context, repo string, h v1.Hash) (int64, error)
+}
+
+// BlobPutHandler is an extension interface representing a blob storage backend
+// that can write blob contents.
+type BlobPutHandler interface {
+	// Put puts the blob contents.
+	//
+	// The contents will be verified against the expected size and digest
+	// as the contents are read, and an error will be returned if these
+	// don't match. Implementations should return that error, or a wrapper
+	// around that error, to return the correct error when these don't match.
+	Put(ctx context.Context, repo string, h v1.Hash, rc io.ReadCloser) error
+}
+
+// BlobDeleteHandler is an extension interface representing a blob storage
+// backend that can delete blob contents.
+type BlobDeleteHandler interface {
+	// Delete the blob contents.
+	Delete(ctx context.Context, repo string, h v1.Hash) error
+}
+
+// redirectError represents a signal that the blob handler doesn't have the blob
+// contents, but that those contents are at another location which registry
+// clients should redirect to.
+type redirectError struct {
+	// Location is the location to find the contents.
+	Location string
+
+	// Code is the HTTP redirect status code to return to clients.
+	Code int
+}
+
+func (e redirectError) Error() string { return fmt.Sprintf("redirecting (%d): %s", e.Code, e.Location) }
+
+// errNotFound represents an error locating the blob.
+var errNotFound = errors.New("not found")
+
+type memHandler struct {
+	m    map[string][]byte
+	lock sync.Mutex
+}
+
+func NewInMemoryBlobHandler() BlobHandler { return &memHandler{m: map[string][]byte{}} }
+
+func (m *memHandler) Stat(_ context.Context, _ string, h v1.Hash) (int64, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	b, found := m.m[h.String()]
+	if !found {
+		return 0, errNotFound
+	}
+	return int64(len(b)), nil
+}
+func (m *memHandler) Get(_ context.Context, _ string, h v1.Hash) (io.ReadCloser, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	b, found := m.m[h.String()]
+	if !found {
+		return nil, errNotFound
+	}
+	return io.NopCloser(bytes.NewReader(b)), nil
+}
+func (m *memHandler) Put(_ context.Context, _ string, h v1.Hash, rc io.ReadCloser) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	defer rc.Close()
+	all, err := io.ReadAll(rc)
+	if err != nil {
+		return err
+	}
+	m.m[h.String()] = all
+	return nil
+}
+func (m *memHandler) Delete(_ context.Context, _ string, h v1.Hash) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if _, found := m.m[h.String()]; !found {
+		return errNotFound
+	}
+
+	delete(m.m, h.String())
+	return nil
+}
+
+// blobs
+type blobs struct {
+	blobHandler BlobHandler
+
+	// Each upload gets a unique id that writes occur to until finalized.
+	uploads map[string][]byte
+	lock    sync.Mutex
+	log     *log.Logger
+}
+
+func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	if elem[len(elem)-1] == "" {
+		elem = elem[:len(elem)-1]
+	}
+	// Must have a path of form /v2/{name}/blobs/{upload,sha256:}
+	if len(elem) < 4 {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "NAME_INVALID",
+			Message: "blobs must be attached to a repo",
+		}
+	}
+	target := elem[len(elem)-1]
+	service := elem[len(elem)-2]
+	digest := req.URL.Query().Get("digest")
+	contentRange := req.Header.Get("Content-Range")
+
+	repo := req.URL.Host + path.Join(elem[1:len(elem)-2]...)
+
+	switch req.Method {
+	case http.MethodHead:
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		var size int64
+		if bsh, ok := b.blobHandler.(BlobStatHandler); ok {
+			size, err = bsh.Stat(req.Context(), repo, h)
+			if errors.Is(err, errNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr redirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+		} else {
+			rc, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, errNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr redirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+			defer rc.Close()
+			size, err = io.Copy(io.Discard, rc)
+			if err != nil {
+				return regErrInternal(err)
+			}
+		}
+
+		resp.Header().Set("Content-Length", fmt.Sprint(size))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.WriteHeader(http.StatusOK)
+		return nil
+
+	case http.MethodGet:
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		var size int64
+		var r io.Reader
+		if bsh, ok := b.blobHandler.(BlobStatHandler); ok {
+			size, err = bsh.Stat(req.Context(), repo, h)
+			if errors.Is(err, errNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr redirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+
+			rc, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, errNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr redirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+
+				return regErrInternal(err)
+			}
+			defer rc.Close()
+			r = rc
+		} else {
+			tmp, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, errNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr redirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+
+				return regErrInternal(err)
+			}
+			defer tmp.Close()
+			var buf bytes.Buffer
+			io.Copy(&buf, tmp)
+			size = int64(buf.Len())
+			r = &buf
+		}
+
+		resp.Header().Set("Content-Length", fmt.Sprint(size))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, r)
+		return nil
+
+	case http.MethodPost:
+		bph, ok := b.blobHandler.(BlobPutHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		// It is weird that this is "target" instead of "service", but
+		// that's how the index math works out above.
+		if target != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("POST to /blobs must be followed by /uploads, got %s", target),
+			}
+		}
+
+		if digest != "" {
+			h, err := v1.NewHash(digest)
+			if err != nil {
+				return regErrDigestInvalid
+			}
+
+			vrc, err := verify.ReadCloser(req.Body, req.ContentLength, h)
+			if err != nil {
+				return regErrInternal(err)
+			}
+			defer vrc.Close()
+
+			if err = bph.Put(req.Context(), repo, h, vrc); err != nil {
+				if errors.As(err, &verify.Error{}) {
+					log.Printf("Digest mismatch: %v", err)
+					return regErrDigestMismatch
+				}
+				return regErrInternal(err)
+			}
+			resp.Header().Set("Docker-Content-Digest", h.String())
+			resp.WriteHeader(http.StatusCreated)
+			return nil
+		}
+
+		id := fmt.Sprint(rand.Int63())
+		resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-2]...), "blobs/uploads", id))
+		resp.Header().Set("Range", "0-0")
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	case http.MethodPatch:
+		if service != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("PATCH to /blobs must be followed by /uploads, got %s", service),
+			}
+		}
+
+		if contentRange != "" {
+			start, end := 0, 0
+			if _, err := fmt.Sscanf(contentRange, "%d-%d", &start, &end); err != nil {
+				return &regError{
+					Status:  http.StatusRequestedRangeNotSatisfiable,
+					Code:    "BLOB_UPLOAD_UNKNOWN",
+					Message: "We don't understand your Content-Range",
+				}
+			}
+			b.lock.Lock()
+			defer b.lock.Unlock()
+			if start != len(b.uploads[target]) {
+				return &regError{
+					Status:  http.StatusRequestedRangeNotSatisfiable,
+					Code:    "BLOB_UPLOAD_UNKNOWN",
+					Message: "Your content range doesn't match what we have",
+				}
+			}
+			l := bytes.NewBuffer(b.uploads[target])
+			io.Copy(l, req.Body)
+			b.uploads[target] = l.Bytes()
+			resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-3]...), "blobs/uploads", target))
+			resp.Header().Set("Range", fmt.Sprintf("0-%d", len(l.Bytes())-1))
+			resp.WriteHeader(http.StatusNoContent)
+			return nil
+		}
+
+		b.lock.Lock()
+		defer b.lock.Unlock()
+		if _, ok := b.uploads[target]; ok {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "BLOB_UPLOAD_INVALID",
+				Message: "Stream uploads after first write are not allowed",
+			}
+		}
+
+		l := &bytes.Buffer{}
+		io.Copy(l, req.Body)
+
+		b.uploads[target] = l.Bytes()
+		resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-3]...), "blobs/uploads", target))
+		resp.Header().Set("Range", fmt.Sprintf("0-%d", len(l.Bytes())-1))
+		resp.WriteHeader(http.StatusNoContent)
+		return nil
+
+	case http.MethodPut:
+		bph, ok := b.blobHandler.(BlobPutHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		if service != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("PUT to /blobs must be followed by /uploads, got %s", service),
+			}
+		}
+
+		if digest == "" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "DIGEST_INVALID",
+				Message: "digest not specified",
+			}
+		}
+
+		b.lock.Lock()
+		defer b.lock.Unlock()
+
+		h, err := v1.NewHash(digest)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		defer req.Body.Close()
+		in := io.NopCloser(io.MultiReader(bytes.NewBuffer(b.uploads[target]), req.Body))
+
+		size := int64(verify.SizeUnknown)
+		if req.ContentLength > 0 {
+			size = int64(len(b.uploads[target])) + req.ContentLength
+		}
+
+		vrc, err := verify.ReadCloser(in, size, h)
+		if err != nil {
+			return regErrInternal(err)
+		}
+		defer vrc.Close()
+
+		if err := bph.Put(req.Context(), repo, h, vrc); err != nil {
+			if errors.As(err, &verify.Error{}) {
+				log.Printf("Digest mismatch: %v", err)
+				return regErrDigestMismatch
+			}
+			return regErrInternal(err)
+		}
+
+		delete(b.uploads, target)
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.WriteHeader(http.StatusCreated)
+		return nil
+
+	case http.MethodDelete:
+		bdh, ok := b.blobHandler.(BlobDeleteHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+		if err := bdh.Delete(req.Context(), repo, h); err != nil {
+			return regErrInternal(err)
+		}
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	default:
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/blobs_disk.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/blobs_disk.go
@@ -1,0 +1,65 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+type diskHandler struct {
+	dir string
+}
+
+func NewDiskBlobHandler(dir string) BlobHandler { return &diskHandler{dir: dir} }
+
+func (m *diskHandler) Stat(_ context.Context, _ string, h v1.Hash) (int64, error) {
+	fi, err := os.Stat(filepath.Join(m.dir, h.String()))
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, errNotFound
+	} else if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}
+func (m *diskHandler) Get(_ context.Context, _ string, h v1.Hash) (io.ReadCloser, error) {
+	return os.Open(filepath.Join(m.dir, h.String()))
+}
+func (m *diskHandler) Put(_ context.Context, _ string, h v1.Hash, rc io.ReadCloser) error {
+	// Put the temp file in the same directory to avoid cross-device problems
+	// during the os.Rename.  The filenames cannot conflict.
+	f, err := os.CreateTemp(m.dir, "upload-*")
+	if err != nil {
+		return err
+	}
+
+	if err := func() error {
+		defer f.Close()
+		_, err := io.Copy(f, rc)
+		return err
+	}(); err != nil {
+		return err
+	}
+
+	return os.Rename(f.Name(), filepath.Join(m.dir, h.String()))
+}
+func (m *diskHandler) Delete(_ context.Context, _ string, h v1.Hash) error {
+	return os.Remove(filepath.Join(m.dir, h.String()))
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/error.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/error.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type regError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (r *regError) Write(resp http.ResponseWriter) error {
+	resp.WriteHeader(r.Status)
+
+	type err struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	type wrap struct {
+		Errors []err `json:"errors"`
+	}
+	return json.NewEncoder(resp).Encode(wrap{
+		Errors: []err{
+			{
+				Code:    r.Code,
+				Message: r.Message,
+			},
+		},
+	})
+}
+
+// regErrInternal returns an internal server error.
+func regErrInternal(err error) *regError {
+	return &regError{
+		Status:  http.StatusInternalServerError,
+		Code:    "INTERNAL_SERVER_ERROR",
+		Message: err.Error(),
+	}
+}
+
+var regErrBlobUnknown = &regError{
+	Status:  http.StatusNotFound,
+	Code:    "BLOB_UNKNOWN",
+	Message: "Unknown blob",
+}
+
+var regErrUnsupported = &regError{
+	Status:  http.StatusMethodNotAllowed,
+	Code:    "UNSUPPORTED",
+	Message: "Unsupported operation",
+}
+
+var regErrDigestMismatch = &regError{
+	Status:  http.StatusBadRequest,
+	Code:    "DIGEST_INVALID",
+	Message: "digest does not match contents",
+}
+
+var regErrDigestInvalid = &regError{
+	Status:  http.StatusBadRequest,
+	Code:    "NAME_INVALID",
+	Message: "invalid digest",
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/manifest.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/manifest.go
@@ -1,0 +1,444 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type catalog struct {
+	Repos []string `json:"repositories"`
+}
+
+type listTags struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+type manifest struct {
+	contentType string
+	blob        []byte
+}
+
+type manifests struct {
+	// maps repo -> manifest tag/digest -> manifest
+	manifests map[string]map[string]manifest
+	lock      sync.RWMutex
+	log       *log.Logger
+}
+
+func isManifest(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "manifests"
+}
+
+func isTags(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "tags"
+}
+
+func isCatalog(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 2 {
+		return false
+	}
+
+	return elems[len(elems)-1] == "_catalog"
+}
+
+// Returns whether this url should be handled by the referrers handler
+func isReferrers(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "referrers"
+}
+
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pulling-an-image-manifest
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pushing-an-image
+func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	target := elem[len(elem)-1]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	switch req.Method {
+	case http.MethodGet:
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		c, ok := m.manifests[repo]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+		m, ok := c[target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		h, _, _ := v1.SHA256(bytes.NewReader(m.blob))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.Header().Set("Content-Type", m.contentType)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(m.blob)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader(m.blob))
+		return nil
+
+	case http.MethodHead:
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		if _, ok := m.manifests[repo]; !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+		m, ok := m.manifests[repo][target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		h, _, _ := v1.SHA256(bytes.NewReader(m.blob))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.Header().Set("Content-Type", m.contentType)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(m.blob)))
+		resp.WriteHeader(http.StatusOK)
+		return nil
+
+	case http.MethodPut:
+		b := &bytes.Buffer{}
+		io.Copy(b, req.Body)
+		h, _, _ := v1.SHA256(bytes.NewReader(b.Bytes()))
+		digest := h.String()
+		mf := manifest{
+			blob:        b.Bytes(),
+			contentType: req.Header.Get("Content-Type"),
+		}
+
+		// If the manifest is a manifest list, check that the manifest
+		// list's constituent manifests are already uploaded.
+		// This isn't strictly required by the registry API, but some
+		// registries require this.
+		if types.MediaType(mf.contentType).IsIndex() {
+			if err := func() *regError {
+				m.lock.RLock()
+				defer m.lock.RUnlock()
+
+				im, err := v1.ParseIndexManifest(b)
+				if err != nil {
+					return &regError{
+						Status:  http.StatusBadRequest,
+						Code:    "MANIFEST_INVALID",
+						Message: err.Error(),
+					}
+				}
+				for _, desc := range im.Manifests {
+					if !desc.MediaType.IsDistributable() {
+						continue
+					}
+					if desc.MediaType.IsIndex() || desc.MediaType.IsImage() {
+						if _, found := m.manifests[repo][desc.Digest.String()]; !found {
+							return &regError{
+								Status:  http.StatusNotFound,
+								Code:    "MANIFEST_UNKNOWN",
+								Message: fmt.Sprintf("Sub-manifest %q not found", desc.Digest),
+							}
+						}
+					} else {
+						// TODO: Probably want to do an existence check for blobs.
+						m.log.Printf("TODO: Check blobs for %q", desc.Digest)
+					}
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+
+		m.lock.Lock()
+		defer m.lock.Unlock()
+
+		if _, ok := m.manifests[repo]; !ok {
+			m.manifests[repo] = make(map[string]manifest, 2)
+		}
+
+		// Allow future references by target (tag) and immutable digest.
+		// See https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier.
+		m.manifests[repo][digest] = mf
+		m.manifests[repo][target] = mf
+		resp.Header().Set("Docker-Content-Digest", digest)
+		resp.WriteHeader(http.StatusCreated)
+		return nil
+
+	case http.MethodDelete:
+		m.lock.Lock()
+		defer m.lock.Unlock()
+		if _, ok := m.manifests[repo]; !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+
+		_, ok := m.manifests[repo][target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		delete(m.manifests[repo], target)
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	default:
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+}
+
+func (m *manifests) handleTags(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	if req.Method == "GET" {
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		c, ok := m.manifests[repo]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+
+		var tags []string
+		for tag := range c {
+			if !strings.Contains(tag, "sha256:") {
+				tags = append(tags, tag)
+			}
+		}
+		sort.Strings(tags)
+
+		// https://github.com/opencontainers/distribution-spec/blob/b505e9cc53ec499edbd9c1be32298388921bb705/detail.md#tags-paginated
+		// Offset using last query parameter.
+		if last := req.URL.Query().Get("last"); last != "" {
+			for i, t := range tags {
+				if t > last {
+					tags = tags[i:]
+					break
+				}
+			}
+		}
+
+		// Limit using n query parameter.
+		if ns := req.URL.Query().Get("n"); ns != "" {
+			if n, err := strconv.Atoi(ns); err != nil {
+				return &regError{
+					Status:  http.StatusBadRequest,
+					Code:    "BAD_REQUEST",
+					Message: fmt.Sprintf("parsing n: %v", err),
+				}
+			} else if n < len(tags) {
+				tags = tags[:n]
+			}
+		}
+
+		tagsToList := listTags{
+			Name: repo,
+			Tags: tags,
+		}
+
+		msg, _ := json.Marshal(tagsToList)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader([]byte(msg)))
+		return nil
+	}
+
+	return &regError{
+		Status:  http.StatusBadRequest,
+		Code:    "METHOD_UNKNOWN",
+		Message: "We don't understand your method + url",
+	}
+}
+
+func (m *manifests) handleCatalog(resp http.ResponseWriter, req *http.Request) *regError {
+	query := req.URL.Query()
+	nStr := query.Get("n")
+	n := 10000
+	if nStr != "" {
+		n, _ = strconv.Atoi(nStr)
+	}
+
+	if req.Method == "GET" {
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		var repos []string
+		countRepos := 0
+		// TODO: implement pagination
+		for key := range m.manifests {
+			if countRepos >= n {
+				break
+			}
+			countRepos++
+
+			repos = append(repos, key)
+		}
+
+		repositoriesToList := catalog{
+			Repos: repos,
+		}
+
+		msg, _ := json.Marshal(repositoriesToList)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader([]byte(msg)))
+		return nil
+	}
+
+	return &regError{
+		Status:  http.StatusBadRequest,
+		Code:    "METHOD_UNKNOWN",
+		Message: "We don't understand your method + url",
+	}
+}
+
+// TODO: implement handling of artifactType querystring
+func (m *manifests) handleReferrers(resp http.ResponseWriter, req *http.Request) *regError {
+	// Ensure this is a GET request
+	if req.Method != "GET" {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	target := elem[len(elem)-1]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	// Validate that incoming target is a valid digest
+	if _, err := v1.NewHash(target); err != nil {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "UNSUPPORTED",
+			Message: "Target must be a valid digest",
+		}
+	}
+
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	digestToManifestMap, repoExists := m.manifests[repo]
+	if !repoExists {
+		return &regError{
+			Status:  http.StatusNotFound,
+			Code:    "NAME_UNKNOWN",
+			Message: "Unknown name",
+		}
+	}
+
+	im := v1.IndexManifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIImageIndex,
+		Manifests:     []v1.Descriptor{},
+	}
+	for digest, manifest := range digestToManifestMap {
+		h, err := v1.NewHash(digest)
+		if err != nil {
+			continue
+		}
+		var refPointer struct {
+			Subject *v1.Descriptor `json:"subject"`
+		}
+		json.Unmarshal(manifest.blob, &refPointer)
+		if refPointer.Subject == nil {
+			continue
+		}
+		referenceDigest := refPointer.Subject.Digest
+		if referenceDigest.String() != target {
+			continue
+		}
+		// At this point, we know the current digest references the target
+		var imageAsArtifact struct {
+			Config struct {
+				MediaType string `json:"mediaType"`
+			} `json:"config"`
+		}
+		json.Unmarshal(manifest.blob, &imageAsArtifact)
+		im.Manifests = append(im.Manifests, v1.Descriptor{
+			MediaType:    types.MediaType(manifest.contentType),
+			Size:         int64(len(manifest.blob)),
+			Digest:       h,
+			ArtifactType: imageAsArtifact.Config.MediaType,
+		})
+	}
+	msg, _ := json.Marshal(&im)
+	resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+	resp.Header().Set("Content-Type", string(types.OCIImageIndex))
+	resp.WriteHeader(http.StatusOK)
+	io.Copy(resp, bytes.NewReader([]byte(msg)))
+	return nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/registry.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/registry.go
@@ -1,0 +1,144 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package registry implements a docker V2 registry and the OCI distribution specification.
+//
+// It is designed to be used anywhere a low dependency container registry is needed, with an
+// initial focus on tests.
+//
+// Its goal is to be standards compliant and its strictness will increase over time.
+//
+// This is currently a low flightmiles system. It's likely quite safe to use in tests; If you're using it
+// in production, please let us know how and send us CL's for integration tests.
+package registry
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+)
+
+type registry struct {
+	log              *log.Logger
+	blobs            blobs
+	manifests        manifests
+	referrersEnabled bool
+	warnings         map[float64]string
+}
+
+// https://docs.docker.com/registry/spec/api/#api-version-check
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#api-version-check
+func (r *registry) v2(resp http.ResponseWriter, req *http.Request) *regError {
+	if r.warnings != nil {
+		rnd := rand.Float64()
+		for prob, msg := range r.warnings {
+			if prob > rnd {
+				resp.Header().Add("Warning", fmt.Sprintf(`299 - "%s"`, msg))
+			}
+		}
+	}
+
+	if isBlob(req) {
+		return r.blobs.handle(resp, req)
+	}
+	if isManifest(req) {
+		return r.manifests.handle(resp, req)
+	}
+	if isTags(req) {
+		return r.manifests.handleTags(resp, req)
+	}
+	if isCatalog(req) {
+		return r.manifests.handleCatalog(resp, req)
+	}
+	if r.referrersEnabled && isReferrers(req) {
+		return r.manifests.handleReferrers(resp, req)
+	}
+	resp.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
+	if req.URL.Path != "/v2/" && req.URL.Path != "/v2" {
+		return &regError{
+			Status:  http.StatusNotFound,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+	resp.WriteHeader(200)
+	return nil
+}
+
+func (r *registry) root(resp http.ResponseWriter, req *http.Request) {
+	if rerr := r.v2(resp, req); rerr != nil {
+		r.log.Printf("%s %s %d %s %s", req.Method, req.URL, rerr.Status, rerr.Code, rerr.Message)
+		rerr.Write(resp)
+		return
+	}
+	r.log.Printf("%s %s", req.Method, req.URL)
+}
+
+// New returns a handler which implements the docker registry protocol.
+// It should be registered at the site root.
+func New(opts ...Option) http.Handler {
+	r := &registry{
+		log: log.New(os.Stderr, "", log.LstdFlags),
+		blobs: blobs{
+			blobHandler: &memHandler{m: map[string][]byte{}},
+			uploads:     map[string][]byte{},
+			log:         log.New(os.Stderr, "", log.LstdFlags),
+		},
+		manifests: manifests{
+			manifests: map[string]map[string]manifest{},
+			log:       log.New(os.Stderr, "", log.LstdFlags),
+		},
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return http.HandlerFunc(r.root)
+}
+
+// Option describes the available options
+// for creating the registry.
+type Option func(r *registry)
+
+// Logger overrides the logger used to record requests to the registry.
+func Logger(l *log.Logger) Option {
+	return func(r *registry) {
+		r.log = l
+		r.manifests.log = l
+		r.blobs.log = l
+	}
+}
+
+// WithReferrersSupport enables the referrers API endpoint (OCI 1.1+)
+func WithReferrersSupport(enabled bool) Option {
+	return func(r *registry) {
+		r.referrersEnabled = enabled
+	}
+}
+
+func WithWarning(prob float64, msg string) Option {
+	return func(r *registry) {
+		if r.warnings == nil {
+			r.warnings = map[float64]string{}
+		}
+		r.warnings[prob] = msg
+	}
+}
+
+func WithBlobHandler(h BlobHandler) Option {
+	return func(r *registry) {
+		r.blobs.blobHandler = h
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/tls.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/tls.go
@@ -1,0 +1,29 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"net/http/httptest"
+
+	ggcrtest "github.com/google/go-containerregistry/internal/httptest"
+)
+
+// TLS returns an httptest server, with an http client that has been configured to
+// send all requests to the returned server. The TLS certs are generated for the given domain
+// which should correspond to the domain the image is stored in.
+// If you need a transport, Client().Transport is correctly configured.
+func TLS(domain string) (*httptest.Server, error) {
+	return ggcrtest.NewTLSServer(domain, New())
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,6 +224,7 @@ github.com/google/go-containerregistry/internal/and
 github.com/google/go-containerregistry/internal/compression
 github.com/google/go-containerregistry/internal/estargz
 github.com/google/go-containerregistry/internal/gzip
+github.com/google/go-containerregistry/internal/httptest
 github.com/google/go-containerregistry/internal/redact
 github.com/google/go-containerregistry/internal/retry
 github.com/google/go-containerregistry/internal/retry/wait
@@ -237,6 +238,7 @@ github.com/google/go-containerregistry/pkg/legacy
 github.com/google/go-containerregistry/pkg/legacy/tarball
 github.com/google/go-containerregistry/pkg/logs
 github.com/google/go-containerregistry/pkg/name
+github.com/google/go-containerregistry/pkg/registry
 github.com/google/go-containerregistry/pkg/v1
 github.com/google/go-containerregistry/pkg/v1/daemon
 github.com/google/go-containerregistry/pkg/v1/empty


### PR DESCRIPTION
[Fixes-375](https://github.com/slimtoolkit/slim/issues/375)
==================================================================

What
===============

Implements the `server` subcommand of `registry` using registry server in the `go-containerregistry` library


How Tested
===============


- [x] Did sanity by running command and randomly checking a few cases from `go-containerregistry` [test suite](https://github.com/google/go-containerregistry/blob/55ffb0092afd1313edad861a553b4fcea21b4da2/pkg/registry/registry_test.go#L71-L72)
- [ ] Todo: Implement `go-containerregistry` [test suite](https://github.com/google/go-containerregistry/blob/55ffb0092afd1313edad861a553b4fcea21b4da2/pkg/registry/registry_test.go#L71-L72) within the package

