### PR TITLE
fix: Increase min Docker API verison requirement to 1.25

### DIFF
--- a/pkg/app/master/command/cliflags.go
+++ b/pkg/app/master/command/cliflags.go
@@ -353,7 +353,7 @@ func GlobalFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:    FlagAPIVersion,
-			Value:   "1.24", //Docker Engine v25.x depricates APIs below 1.24
+			Value:   "1.25", // We need at least 1.25 for to support builds from Dockerfile.
 			Usage:   FlagAPIVersionUsage,
 			EnvVars: []string{"DSLIM_CRT_API_VER"},
 		},

--- a/pkg/app/sensor/controlled/controlled_test.go
+++ b/pkg/app/sensor/controlled/controlled_test.go
@@ -42,6 +42,7 @@ func newStubMonitorFunc(
 	) (monitor.CompositeMonitor, error) {
 		return monitor.Compose(
 			cmd,
+			nil,
 			fanMon,
 			ptMon,
 			nil,

--- a/pkg/docker/dockerimage/dockerimage.go
+++ b/pkg/docker/dockerimage/dockerimage.go
@@ -2122,7 +2122,7 @@ func jsonFromStream(source string, name string, reader io.Reader, data interface
 
 	sr := strings.NewReader(string(raw))
 	log.Tracef("dockerimage.LoadPackage.jsonFromStream: name='%s' data[%d]='%s' source='%s'",
-		name, raw, len(raw), source)
+		name, len(raw), string(raw), source)
 
 	return json.NewDecoder(sr).Decode(data)
 }


### PR DESCRIPTION
The slim build --dockerfile command uses the Docker Build API feature(s) that become available only in versions >= 1.25.

Bonus: Fix compilation errors in unit tests.