### PR TITLE
--use-local-mounts=true will fail

### DIFF
--- a/pkg/app/master/command/build/image.go
+++ b/pkg/app/master/command/build/image.go
@@ -395,7 +395,7 @@ func buildOutputImage(
 			hasData = true
 		} else {
 			dataDir := filepath.Join(imageInspector.ArtifactLocation, "files")
-			if fsutil.Exists(dataTar) && fsutil.IsDir(dataDir) {
+			if fsutil.Exists(dataDir) && fsutil.IsDir(dataDir) {
 				layerInfo := imagebuilder.LayerDataInfo{
 					Type:   imagebuilder.DirSource,
 					Source: dataDir,


### PR DESCRIPTION
pkg/app/master/command/build/image.go

[Fixes-###](https://github.com/docker-slim/docker-slim/issues/###)
==================================================================

What
===============
When I run `slim build` with `--use-local-mounts=true` and provide local state-path. Then the slim build will fail with error
```
cmd=build info=build.error status='optimized.image.build.error' error='no layers' 
```

Why
===============
The reason is for local mounts, there is no `files.tar` file exits. Only the `files` folder exists. But the check is
```
dataDir := filepath.Join(imageInspector.ArtifactLocation, "files")
if fsutil.Exists(dataTar) && fsutil.IsDir(dataDir) {
  layerInfo := imagebuilder.LayerDataInfo{
	  Type:   imagebuilder.DirSource,
	  Source: dataDir,
	  Params: &imagebuilder.DataParams{
		  TargetPath: "/",
	  },
  }
  
  opts.Layers = append(opts.Layers, layerInfo)
  hasData = true
} else {
  logger.Info("WARNING - no data artifacts")
}
```
which will check if dataTar exists. In this case, it is false, so it will trigger the failure

How Tested
===============
set `--use-local-mounts=true` and provide your local `--state-path`

